### PR TITLE
Fix linkage failure of libmatroska due to missing -lebml flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ libmatroska_la_SOURCES = \
 	src/KaxSemantic.cpp \
 	src/KaxTracks.cpp \
 	src/KaxVersion.cpp
-libmatroska_la_LDFLAGS = -version-info 6:0:0 -no-undefined
+libmatroska_la_LDFLAGS = $(EBML_LIBS) -version-info 6:0:0 -no-undefined
 
 nobase_include_HEADERS = \
 	matroska/c/libmatroska.h \


### PR DESCRIPTION
Without this change the following linkage error occurs:

    /bin/sh ./libtool  --tag=CXX   --mode=link g++ -Wall -Wextra \
      -Wno-unknown-pragmas -Wshadow -I/usr/pkg/include   -pipe -O2 \
      -I/usr/pkg/include -version-info 6:0:0 -no-undefined -L/usr/pkg/lib \
      -o libmatroska.la -rpath /usr/pkg/lib src/FileKax.lo \
      src/KaxAttached.lo src/KaxAttachments.lo src/KaxBlock.lo \
      src/KaxBlockData.lo src/KaxCluster.lo src/KaxContexts.lo \
      src/KaxCues.lo src/KaxCuesData.lo src/KaxInfoData.lo \
      src/KaxSeekHead.lo src/KaxSegment.lo src/KaxSemantic.lo \
      src/KaxTracks.lo src/KaxVersion.lo
    Undefined symbols:
      "libebml::EbmlUnicodeString::EbmlUnicodeString()", referenced from:
          libmatroska::KaxSegmentFilename::KaxSegmentFilename()in KaxSemantic.o
          libmatroska::KaxPrevFilename::KaxPrevFilename()in KaxSemantic.o
          libmatroska::KaxNextFilename::KaxNextFilename()in KaxSemantic.o
          ...