### PR TITLE
Some optimizations

### DIFF
--- a/src/FileKax.cpp
+++ b/src/FileKax.cpp
@@ -280,7 +280,7 @@ inline bool FileMatroska::IsMyTrack(const Track * aTrack) const
   if (aTrack == 0)
     throw 0;
 
-  for (std::vector<Track*>::const_iterator i = myTracks.begin(); i != myTracks.end(); i ++) {
+  for (std::vector<Track*>::const_iterator i = myTracks.begin(); i != myTracks.end(); ++i) {
     if (*i == aTrack)
       break;
   }
@@ -296,7 +296,7 @@ void FileMatroska::SelectReadingTrack(Track * aTrack, bool select)
   if (IsMyTrack(aTrack)) {
     // here we have the right track
     // check if it's not already selected
-    for (std::vector<uint8>::iterator j = mySelectedTracks.begin(); j != mySelectedTracks.end(); j ++) {
+    for (std::vector<uint8>::iterator j = mySelectedTracks.begin(); j != mySelectedTracks.end(); ++j) {
       if (*j == aTrack->TrackNumber())
         break;
     }
@@ -314,7 +314,7 @@ inline bool FileMatroska::IsReadingTrack(const uint8 aTrackNumber) const
 {
   for (std::vector<uint8>::const_iterator trackIdx = mySelectedTracks.begin();
        trackIdx != mySelectedTracks.end() && *trackIdx < aTrackNumber;
-       trackIdx++) {}
+       ++trackIdx) {}
 
   if (trackIdx == mySelectedTracks.end())
     return false;

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -89,7 +89,7 @@ KaxInternalBlock::KaxInternalBlock(const KaxInternalBlock & ElementToClone)
   std::vector<DataBuffer *>::iterator myItr = myBuffers.begin();
   while (Itr != ElementToClone.myBuffers.end()) {
     *myItr = (*Itr)->Clone();
-    Itr++; myItr++;
+    ++Itr; ++myItr;
   }
 }
 

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -822,6 +822,7 @@ int main(int argc, char **argv)
       }
       else cout << "received a frame from an unwanted track" << endl;
   }
+  delete[] Tracks;
 #endif // OLD
     }
     catch (exception & Ex)


### PR DESCRIPTION
(performance) Prefer prefix ++/-- operators for non-primitive types
I also fixed a memory leak in the tests when OLD is defined.