### PR TITLE
Remove explict CMAKE_MODULE_PATH set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ project(matroska VERSION 1.4.9)
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)
 
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 find_package(Ebml 1.3.5 REQUIRED)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Solution for #18 

Currently, CMAKE_MODULE_PATH is expliclty overridden and set to
"${CMAKE_CURRENT_SOURCE_DIR}/cmake/". Since that directory does not
exist this prevents anyone from writing a FindEbml.cmake file. This
works if you are consuming libeml by installing it on your system.

This breaks the use case of having libebml built as part of your build.
If you have called add_subdirectory(libebml) already, the build should
be able to continue. I'm removing the explict set of CMAKE_MODULE_PATH
to allow this use case.