### PR TITLE
KaxBlock: don't reset potentially unallocated memory

### DIFF
--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -703,7 +703,6 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
   } catch (SafeReadIOCallback::EndOfStreamX &) {
     SetValueIsSet(false);
 
-    std::memset(EbmlBinary::GetBuffer(), 0, GetSize());
     myBuffers.clear();
     SizeList.clear();
     Timecode           = 0;


### PR DESCRIPTION
When using SCOPE_PARTIAL_DATA the GetBuffer()/Data pointer is never allocated.
If this exception occurs we must not write on NULL pointed data.

When the memory is allocated it doesn't have any use to reset the memory to 0
since SetValueIsSet(false) is called right before, invalidating the buffer.