### PR TITLE
#35: Fixed linking against libmatroska.dll (lib)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,16 +64,25 @@ target_link_libraries(matroska PUBLIC EBML::ebml)
 set_target_properties(matroska PROPERTIES
   VERSION 6.0.0
   SOVERSION 6)
-target_include_directories(matroska PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_include_directories(matroska
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+	PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 if(MSVC)
   target_compile_definitions(matroska PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
-if(BUILD_SHARED_LIBS)
-  target_compile_definitions(matroska PUBLIC MATROSKA_DLL)
-  set_target_properties(matroska PROPERTIES
-    DEFINE_SYMBOL MATROSKA_DLL_EXPORT)
+
+include(GenerateExportHeader)
+generate_export_header(matroska EXPORT_MACRO_NAME MATROSKA_DLL_API)
+target_sources(matroska
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}/matroska_export.h
+)
+
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_definitions(matroska PUBLIC MATROSKA_STATIC_DEFINE)
 endif()
 
 install(TARGETS matroska
@@ -84,6 +93,7 @@ install(TARGETS matroska
 
 install(FILES ${libmatroska_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/matroska)
 install(FILES ${libmatroska_C_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/matroska/c)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/matroska_export.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/matroska)
 
 if(NOT DISABLE_PKGCONFIG)
   set(prefix ${CMAKE_INSTALL_PREFIX})

--- a/matroska/KaxConfig.h
+++ b/matroska/KaxConfig.h
@@ -44,23 +44,7 @@
 # define END_LIBMATROSKA_NAMESPACE   }
 #endif // NO_NAMESPACE
 
-// There are special implementations for certain platforms. For example on Windows
-// we use the Win32 file API. here we set the appropriate macros.
-#if defined(_WIN32)||defined(WIN32)
-
-# if defined(MATROSKA_DLL)
-#  if defined(MATROSKA_DLL_EXPORT)
-#   define MATROSKA_DLL_API __declspec(dllexport)
-#  else // MATROSKA_DLL_EXPORT
-#   define MATROSKA_DLL_API __declspec(dllimport)
-#  endif // MATROSKA_DLL_EXPORT
-# else // MATROSKA_DLL
-#  define MATROSKA_DLL_API
-# endif // MATROSKA_DLL
-
-#else
-# define MATROSKA_DLL_API
-#endif
+#include "matroska_export.h"
 
 #if !defined(MATROSKA_VERSION)
 #define MATROSKA_VERSION  2

--- a/matroska/KaxVersion.h
+++ b/matroska/KaxVersion.h
@@ -42,8 +42,8 @@ START_LIBMATROSKA_NAMESPACE
 
 #define LIBMATROSKA_VERSION 0x010502
 
-extern const std::string KaxCodeVersion;
-extern const std::string KaxCodeDate;
+extern const MATROSKA_DLL_API std::string KaxCodeVersion;
+extern const MATROSKA_DLL_API std::string KaxCodeDate;
 
 /*!
   \todo Improve the CRC/ECC system (backward and forward possible ?) to fit streaming/live writing/simple reading


### PR DESCRIPTION
For fixing the link problems I applied constructs, which are use in libebml already. 

1. Using CMake for generating the MATROSKA_DLL_API macros.
2. Expporting the variable KaxCodeVersion and KaxCodeVersion

With those changes I was able to link the libmatroska.dll(lib) and libebml.dll(lib) and create a MKV video. (VLC could play it.)

Furthermore, I build the libmatroska library with Linux. But I haven't tested yet, if write a video actually works.