### PR TITLE
CMakeLists.txt: set default visibility to hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(matroska VERSION 1.5.2)
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 find_package(EBML 1.3.9 REQUIRED)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
It will hide all symbols that are not marked with the MATROSKA_DLL_API
macro. It also reduces the size of dynamic builds from 1.3Mo to 1.1Mo.

Before this change:
$ objdump -T libmatroska.so.6.0.0 | wc -l
4672

After this change:
$ objdump -T libmatroska.so.6.0.0 | wc -l
2102

Tested on Linux for now.