### PR TITLE
Allow writing TrackTimecodeScale

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -254,8 +254,6 @@ DECLARE_MKX_UINTEGER(KaxTrackDefaultDecodedFieldDuration)
 #endif
 
 DECLARE_MKX_FLOAT(KaxTrackTimecodeScale)
-public:
-  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 #if MATROSKA_VERSION >= 2

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -828,11 +828,6 @@ filepos_t KaxEncryptedBlock::RenderData(IOCallback & /* output */, bool /* bForc
   return 0;
 }
 
-filepos_t KaxTrackTimecodeScale::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
-  assert(false); // no you are not allowed to use this element !
-  return 0;
-}
-
 filepos_t KaxTrackOffset::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
   assert(false); // no you are not allowed to use this element !
   return 0;


### PR DESCRIPTION
TrackTimestampScale/TrackTimecodeScale was allowed until Matroska v3 so it
should be possible to remux files with the value.