### PR TITLE
Do not allow writing any DivX elements anymore

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -189,12 +189,18 @@ public:
 };
 
 DECLARE_MKX_MASTER(KaxReferenceFrame)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 DECLARE_MKX_UINTEGER(KaxReferenceOffset)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 DECLARE_MKX_UINTEGER(KaxReferenceTimeCode)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 DECLARE_MKX_BINARY (KaxEncryptedBlock)
@@ -526,21 +532,29 @@ DECLARE_MKX_UINTEGER(KaxTrackJoinUID)
 };
 
 DECLARE_MKX_UINTEGER(KaxTrickTrackUID)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 DECLARE_MKX_BINARY (KaxTrickTrackSegmentUID)
 public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
   virtual bool ValidateSize() const {return IsFiniteSize() && GetSize() == 16;}
 };
 
 DECLARE_MKX_UINTEGER(KaxTrickTrackFlag)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 DECLARE_MKX_UINTEGER(KaxTrickMasterTrackUID)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 DECLARE_MKX_BINARY (KaxTrickMasterTrackSegmentUID)
 public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
   virtual bool ValidateSize() const {return IsFiniteSize() && GetSize() == 16;}
 };
 

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -771,6 +771,21 @@ filepos_t KaxSliceDuration::RenderData(IOCallback & /* output */, bool /* bForce
   return 0;
 }
 
+filepos_t KaxReferenceFrame::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxReferenceOffset::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxReferenceTimeCode::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
 filepos_t KaxEncryptedBlock::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
   assert(false); // no you are not allowed to use this element !
   return 0;
@@ -817,6 +832,31 @@ filepos_t KaxVideoFrameRate::RenderData(IOCallback & /* output */, bool /* bForc
 }
 
 filepos_t KaxAudioPosition::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrickTrackUID::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrickTrackSegmentUID::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrickTrackFlag::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrickMasterTrackUID::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrickMasterTrackSegmentUID::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
   assert(false); // no you are not allowed to use this element !
   return 0;
 }


### PR DESCRIPTION
Some were allowed while some were forbidden. Noone is probably writing such
files anymore.

Maybe there could be a compilation flag to still allow them if anyone wants to
remux these files. But v4 should not be used with such flags.

New DivX elements that cannot be written anymore:
- ReferenceFrame
- ReferenceOffset
- ReferenceTimeCode
- TrickTrackUID
- TrickTrackSegmentUID
- TrickTrackFlag
- TrickMasterTrackUID
- TrickMasterTrackSegmentUID

DivX elements that wre not allowed to be written:
- FileUsedStartTime
- FileUsedEndTime