### PR TITLE
Do not allow writing KaxTrackTimecodeScale anymore

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -249,6 +249,8 @@ DECLARE_MKX_UINTEGER(KaxTrackDefaultDecodedFieldDuration)
 };
 
 DECLARE_MKX_FLOAT(KaxTrackTimecodeScale)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault);
 };
 
 DECLARE_MKX_SINTEGER(KaxTrackOffset)

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -776,6 +776,11 @@ filepos_t KaxEncryptedBlock::RenderData(IOCallback & /* output */, bool /* bForc
   return 0;
 }
 
+filepos_t KaxTrackTimecodeScale::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
 filepos_t KaxTrackOffset::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
   assert(false); // no you are not allowed to use this element !
   return 0;


### PR DESCRIPTION
This is deprecated in v3 and likely never worked as it requires improper (scaled)
muxing or demuxing needs a growing buffer to counter the timestamps shifts
between tracks.

TrackAttachmentLink is another element that was allowed until Matroska v3 but
is not allowed to be written anymore.