### PR TITLE
allow reading the stored/raw timestamp value of a Block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 
-project(matroska VERSION 1.6.3)
+project(matroska VERSION 1.6.4)
 
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@
 
         * Remove Coremake project files
 
+        * Add GetRelativeTimestamp() to access unscaled Block timestamps.
+
 2021-02-18  Moritz Bunkus  <mo@bunkus.online>
 
         * Release v1.6.3.

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -267,6 +267,12 @@ class MATROSKA_DLL_API KaxInternalBlock : public EbmlBinary {
 
     uint64 ClusterPosition() const;
 
+    /*!
+     * \return Get the timestamp as written in the Block (not scaled).
+     * \since LIBMATROSKA_VERSION >= 0x010604
+     */
+    int16 GetRelativeTimestamp() const { return LocalTimecode; }
+
   protected:
     std::vector<DataBuffer *> myBuffers;
     std::vector<int32>        SizeList;

--- a/matroska/KaxVersion.h
+++ b/matroska/KaxVersion.h
@@ -40,7 +40,7 @@
 
 START_LIBMATROSKA_NAMESPACE
 
-#define LIBMATROSKA_VERSION 0x010603
+#define LIBMATROSKA_VERSION 0x010604
 
 extern const MATROSKA_DLL_API std::string KaxCodeVersion;
 extern const MATROSKA_DLL_API std::string KaxCodeDate;

--- a/src/KaxVersion.cpp
+++ b/src/KaxVersion.cpp
@@ -37,7 +37,7 @@
 
 START_LIBMATROSKA_NAMESPACE
 
-const std::string KaxCodeVersion = "1.6.3";
+const std::string KaxCodeVersion = "1.6.4";
 
 // Up to version 1.4.4 this library exported a build date string. As
 // this made the build non-reproducible, replace it by a placeholder to


### PR DESCRIPTION
Given the API to get the GlobalTimecode of a Block doesn't handle the floating
point value of the TrackTimestampScale (attaching a parent track is not common
and even though the value is not directly available unlike a fractional
timestampscale), it allows external code to compute the proper timestamp
when TrackTimestampScale is not 1.0.

Ultimately the whole way of computing the GlobalTimecode of a block should change but that's probably for a v2.0