### PR TITLE
bump C++ requirement to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(EBML 1.4.2 REQUIRED)
 
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(libmatroska_SOURCES

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ a C++ library to parse and create Matroska files
 
 ## Building and installing the library
 
-libmatroska is based on `cmake`. It requires a C++ compiler as well as
+libmatroska is based on `cmake`. It requires a C++ compiler compatible
+with the C++14 standard as well as
 [libebml](https://github.com/Matroska-Org/libebml). This means that
 the normal build process consists of the usual steps:
 


### PR DESCRIPTION
This follows libebml's recent bump to C++14.