### PR TITLE
bump soname to 8 due to ABI-breaking changes & bump version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 
-project(matroska VERSION 1.7.0)
+project(matroska VERSION 1.8.0)
 
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)
@@ -65,8 +65,8 @@ set (libmatroska_C_PUBLIC_HEADERS
 add_library(matroska ${libmatroska_SOURCES} ${libmatroska_PUBLIC_HEADERS} ${libmatroska_C_PUBLIC_HEADERS})
 target_link_libraries(matroska PUBLIC EBML::ebml)
 set_target_properties(matroska PROPERTIES
-  VERSION 7.0.0
-  SOVERSION 7
+  VERSION 8.0.0
+  SOVERSION 8
   CXX_VISIBILITY_PRESET hidden
   VISIBILITY_INLINES_HIDDEN ON
 )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Version 1.8.0 2022-??-??
+
+* Bumped the library's soname to 8 due to ABI breaking changes that
+  already happened in 1.7.0.
+
 # Version 1.7.0 2022-09-30
 
 * A C++14 compliant C++ compiler is now required.

--- a/matroska/KaxVersion.h
+++ b/matroska/KaxVersion.h
@@ -40,7 +40,7 @@
 
 namespace libmatroska {
 
-#define LIBMATROSKA_VERSION 0x010700
+#define LIBMATROSKA_VERSION 0x010800
 
 extern const MATROSKA_DLL_API std::string KaxCodeVersion;
 extern const MATROSKA_DLL_API std::string KaxCodeDate;

--- a/src/KaxVersion.cpp
+++ b/src/KaxVersion.cpp
@@ -37,7 +37,7 @@
 
 namespace libmatroska {
 
-const std::string KaxCodeVersion = "1.7.0";
+const std::string KaxCodeVersion = "1.8.0";
 
 // Up to version 1.4.4 this library exported a build date string. As
 // this made the build non-reproducible, replace it by a placeholder to


### PR DESCRIPTION
libEBML needed an soname bump due to being compiled in C++14, therefore libMatroska cannot stay on the same soname either. See https://github.com/Matroska-Org/libebml/issues/104