### PR TITLE
replace EBML_PRETTYLONGINT by the standard UINT64_MAX macro

### DIFF
--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -117,7 +117,7 @@ const KaxCuePoint * KaxCues::GetTimecodePoint(uint64 aTimecode) const
   const uint64 TimecodeToLocate = aTimecode / GlobalTimecodeScale();
   const KaxCuePoint * aPointPrev = nullptr;
   uint64 aPrevTime = 0;
-  uint64 aNextTime = UINT64_C(0xFFFFFFFFFFFF);
+  uint64 aNextTime = UINT64_MAX;
 
   EBML_MASTER_CONST_ITERATOR Itr;
   for (Itr = begin(); Itr != end(); ++Itr) {

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -31,6 +31,7 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 #include <cassert>
+#include <cstdint>
 
 #include "matroska/KaxCues.h"
 #include "matroska/KaxCuesData.h"
@@ -116,7 +117,7 @@ const KaxCuePoint * KaxCues::GetTimecodePoint(uint64 aTimecode) const
   const uint64 TimecodeToLocate = aTimecode / GlobalTimecodeScale();
   const KaxCuePoint * aPointPrev = nullptr;
   uint64 aPrevTime = 0;
-  uint64 aNextTime = EBML_PRETTYLONGINT(0xFFFFFFFFFFFF);
+  uint64 aNextTime = UINT64_C(0xFFFFFFFFFFFF);
 
   EBML_MASTER_CONST_ITERATOR Itr;
   for (Itr = begin(); Itr != end(); ++Itr) {

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -209,7 +209,7 @@ bool KaxCuePoint::Timecode(uint64 & aTimecode, uint64 GlobalTimecodeScale) const
 const KaxCueTrackPositions * KaxCuePoint::GetSeekPosition() const
 {
   const KaxCueTrackPositions * result = nullptr;
-  uint64 aPosition = UINT64_C(0xFFFFFFFFFFFFFFF);
+  uint64 aPosition = UINT64_MAX;
   // find the position of the "earlier" Cluster
   auto aPoss = static_cast<const KaxCueTrackPositions *>(FindFirstElt(EBML_INFO(KaxCueTrackPositions)));
   while (aPoss != nullptr) {

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -31,6 +31,7 @@
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 #include <cassert>
+#include <cstdint>
 
 #include "matroska/KaxCuesData.h"
 #include "matroska/KaxContexts.h"
@@ -208,7 +209,7 @@ bool KaxCuePoint::Timecode(uint64 & aTimecode, uint64 GlobalTimecodeScale) const
 const KaxCueTrackPositions * KaxCuePoint::GetSeekPosition() const
 {
   const KaxCueTrackPositions * result = nullptr;
-  uint64 aPosition = EBML_PRETTYLONGINT(0xFFFFFFFFFFFFFFF);
+  uint64 aPosition = UINT64_C(0xFFFFFFFFFFFFFFF);
   // find the position of the "earlier" Cluster
   auto aPoss = static_cast<const KaxCueTrackPositions *>(FindFirstElt(EBML_INFO(KaxCueTrackPositions)));
   while (aPoss != nullptr) {


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/types/integer

Ref. https://github.com/Matroska-Org/libebml/pull/59