### PR TITLE
require libEBML 2.0.0 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(matroska VERSION 1.8.0)
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)
 
-find_package(EBML 1.4.3 REQUIRED)
+find_package(EBML 2.0.0 REQUIRED)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
libEBML currently installs the cmake module config with "COMPATIBILITY SameMajorVersion", meaning we cannot request "version 1.4.3 or 2.0.0 or newer" in libMatroska. As libEBML 2.0.0 is an API-breaking change anyway, it libMatroska should not pretend to continue working with < 2.0.0 anyway.