### PR TITLE
[1.x] build actions on 1.x should checkout the libebml v1.x branch

### DIFF
--- a/.github/workflows/linux-gcc10.yaml
+++ b/.github/workflows/linux-gcc10.yaml
@@ -20,7 +20,7 @@ jobs:
         with: 
           repository: Matroska-Org/libebml
           path: libebml
-          # minimum version we support ref: 'release-1.4.3'
+          ref: v1.x
 
       - name: Configure libebml
         run: cmake -S libebml -B libebml/_build

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,7 +20,7 @@ jobs:
         with: 
           repository: Matroska-Org/libebml
           path: libebml
-          # minimum version we support ref: 'release-1.4.3'
+          ref: v1.x
 
       - name: Configure libebml
         run: cmake -S libebml -B libebml/_build

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -20,7 +20,7 @@ jobs:
         with: 
           repository: Matroska-Org/libebml
           path: libebml
-          # minimum version we support ref: 'release-1.4.3'
+          ref: v1.x
 
       - name: Configure libebml
         run: cmake -S libebml -B libebml/_build

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -24,7 +24,7 @@ jobs:
         with: 
           repository: Matroska-Org/libebml
           path: libebml
-          # minimum version we support ref: 'release-1.4.3'
+          ref: v1.x
 
       - name: Configure libebml
         run: cmake -S libebml -B libebml/_build


### PR DESCRIPTION
(this PR will be merged into the `v1.x` branch and not the `master` branch)