### PR TITLE
replace EBML_PRETTYLONGINT with proper C++ integer literal

### DIFF
--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -114,7 +114,7 @@ const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimecode) const
   const std::uint64_t TimecodeToLocate = aTimecode / GlobalTimecodeScale();
   const KaxCuePoint * aPointPrev = nullptr;
   std::uint64_t aPrevTime = 0;
-  std::uint64_t aNextTime = EBML_PRETTYLONGINT(0xFFFFFFFFFFFF);
+  std::uint64_t aNextTime = 0xFFFFFFFFFFFFLL;
 
   for (const auto& e : *this) {
     if (EbmlId(*e) == EBML_ID(KaxCuePoint)) {

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -197,7 +197,7 @@ bool KaxCuePoint::Timecode(std::uint64_t & aTimecode, std::uint64_t GlobalTimeco
 const KaxCueTrackPositions * KaxCuePoint::GetSeekPosition() const
 {
   const KaxCueTrackPositions * result = nullptr;
-  std::uint64_t aPosition = EBML_PRETTYLONGINT(0xFFFFFFFFFFFFFFF);
+  std::uint64_t aPosition = 0xFFFFFFFFFFFFFFFLL;
   // find the position of the "earlier" Cluster
   auto aPoss = static_cast<const KaxCueTrackPositions *>(FindFirstElt(EBML_INFO(KaxCueTrackPositions)));
   while (aPoss) {


### PR DESCRIPTION
The suffix l/L and ll/LL can/should be used:
https://en.cppreference.com/w/cpp/language/integer_literal

This is equivalent to the previous code with gcc/clang. Theoretically it should be used to write in a long( long) and for uint64_t values we should use UINT64_C().