### PR TITLE
clang-tidy: remove non const operator

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -328,10 +328,8 @@ public:
   }
 
   operator KaxBlockGroup &() const;
-  operator const KaxBlockGroup &() const;
   operator KaxSimpleBlock &() const;
   operator KaxInternalBlock &() const;
-  operator const KaxInternalBlock &() const;
 
   void SetBlockGroup( KaxBlockGroup &BlockRef );
 

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -327,10 +327,10 @@ public:
       delete Block.group;
   }
 
-  operator KaxBlockGroup &();
+  operator KaxBlockGroup &() const;
   operator const KaxBlockGroup &() const;
-  operator KaxSimpleBlock &();
-  operator KaxInternalBlock &();
+  operator KaxSimpleBlock &() const;
+  operator KaxInternalBlock &() const;
   operator const KaxInternalBlock &() const;
 
   void SetBlockGroup( KaxBlockGroup &BlockRef );

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -939,22 +939,7 @@ KaxBlockBlob::operator KaxBlockGroup &() const
   return *Block.group;
 }
 
-KaxBlockBlob::operator const KaxBlockGroup &() const
-{
-  assert(!bUseSimpleBlock);
-  assert(Block.group);
-  return *Block.group;
-}
-
 KaxBlockBlob::operator KaxInternalBlock &() const
-{
-  assert(Block.group);
-  if (bUseSimpleBlock)
-    return *Block.simpleblock;
-  return *Block.group;
-}
-
-KaxBlockBlob::operator const KaxInternalBlock &() const
 {
   assert(Block.group);
   if (bUseSimpleBlock)

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -932,7 +932,7 @@ std::int64_t KaxInternalBlock::GetFrameSize(std::size_t FrameNumber)
   return _Result;
 }
 
-KaxBlockBlob::operator KaxBlockGroup &()
+KaxBlockBlob::operator KaxBlockGroup &() const
 {
   assert(!bUseSimpleBlock);
   assert(Block.group);
@@ -946,7 +946,7 @@ KaxBlockBlob::operator const KaxBlockGroup &() const
   return *Block.group;
 }
 
-KaxBlockBlob::operator KaxInternalBlock &()
+KaxBlockBlob::operator KaxInternalBlock &() const
 {
   assert(Block.group);
   if (bUseSimpleBlock)
@@ -962,7 +962,7 @@ KaxBlockBlob::operator const KaxInternalBlock &() const
   return *Block.group;
 }
 
-KaxBlockBlob::operator KaxSimpleBlock &()
+KaxBlockBlob::operator KaxSimpleBlock &() const
 {
   assert(bUseSimpleBlock);
   assert(Block.simpleblock);
@@ -985,8 +985,8 @@ bool KaxBlockBlob::AddFrameAuto(const KaxTrackEntry & track, std::uint64_t timec
       Block.simpleblock->SetDiscardable(false);
     } else {
       Block.simpleblock->SetKeyframe(false);
-      if ((!ForwBlock || static_cast<const KaxInternalBlock &>(*ForwBlock).GlobalTimecode() <= timecode) &&
-          (!PastBlock || static_cast<const KaxInternalBlock &>(*PastBlock).GlobalTimecode() <= timecode))
+      if ((!ForwBlock || static_cast<KaxInternalBlock &>(*ForwBlock).GlobalTimecode() <= timecode) &&
+          (!PastBlock || static_cast<KaxInternalBlock &>(*PastBlock).GlobalTimecode() <= timecode))
         Block.simpleblock->SetDiscardable(false);
       else
         Block.simpleblock->SetDiscardable(true);

--- a/src/KaxBlockData.cpp
+++ b/src/KaxBlockData.cpp
@@ -76,7 +76,7 @@ filepos_t KaxReferenceBlock::UpdateSize(bool bSaveDefault, bool bForceRender)
     assert(RefdBlock);
     assert(ParentBlock);
 
-    const auto &block = static_cast<const KaxInternalBlock&>(*RefdBlock);
+    auto &block = static_cast<KaxInternalBlock&>(*RefdBlock);
     SetValue(static_cast<std::int64_t>(block.GlobalTimecode()) - static_cast<std::int64_t>(ParentBlock->GlobalTimecode()) / static_cast<std::int64_t>(ParentBlock->GlobalTimecodeScale()));
   }
   return EbmlSInteger::UpdateSize(bSaveDefault, bForceRender);

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -93,7 +93,7 @@ void KaxCues::PositionSet(const KaxBlockGroup & BlockRef)
   // look for the element in the temporary references
   auto it = std::find_if(myTempReferences.begin(), myTempReferences.end(),
     [&](const KaxBlockBlob *myTempReference)
-      { const auto &refTmp = static_cast<const KaxInternalBlock &>(*myTempReference);
+      { auto& refTmp = static_cast<KaxInternalBlock &>(*myTempReference);
         return refTmp.GlobalTimecode() == BlockRef.GlobalTimecode()
             && refTmp.TrackNum() == BlockRef.TrackNumber(); });
 

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -78,11 +78,11 @@ void KaxCuePoint::PositionSet(const KaxBlockGroup & BlockReference, std::uint64_
 
 void KaxCuePoint::PositionSet(const KaxBlockBlob & BlobReference, std::uint64_t GlobalTimecodeScale)
 {
-  const auto &BlockReference = static_cast<const KaxInternalBlock&>(BlobReference);
+  auto &BlockReference = static_cast<KaxInternalBlock&>(BlobReference);
   const KaxBlockGroup *BlockGroupPointer = nullptr;
 
   if (!BlobReference.IsSimpleBlock()) {
-    const auto &BlockGroup = static_cast<const KaxBlockGroup&>(BlobReference);
+    auto &BlockGroup = static_cast<KaxBlockGroup&>(BlobReference);
     BlockGroupPointer = &BlockGroup;
   }
   PositionSet(BlockReference, BlockGroupPointer, GlobalTimecodeScale);
@@ -133,8 +133,8 @@ void KaxCuePoint::PositionSet(const KaxInternalBlock & BlockReference, const Kax
 */
 void KaxCueReference::AddReference(const KaxBlockBlob & BlockReference, std::uint64_t GlobalTimecodeScale)
 {
-  const auto& theBlock = static_cast<const KaxInternalBlock&>(BlockReference);
-  auto & NewTime = GetChild<KaxCueRefTime>(*this);
+  auto& theBlock = static_cast<KaxInternalBlock&>(BlockReference);
+  auto& NewTime = GetChild<KaxCueRefTime>(*this);
   *static_cast<EbmlUInteger*>(&NewTime) = theBlock.GlobalTimecode() / GlobalTimecodeScale;
 
   auto & TheClustPos = GetChild<KaxCueRefCluster>(*this);


### PR DESCRIPTION
Found with readability-make-member-function-const

Signed-off-by: Rosen Penev <rosenp@gmail.com>