### PR TITLE
deprecate the Min/Max pseudo-cache values

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -254,9 +254,13 @@ DECLARE_MKX_UINTEGER(KaxTrackFlagLacing)
 };
 
 DECLARE_MKX_UINTEGER(KaxTrackMinCache)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault) override;
 };
 
 DECLARE_MKX_UINTEGER(KaxTrackMaxCache)
+public:
+  filepos_t RenderData(IOCallback & output, bool bForceRender, bool bSaveDefault) override;
 };
 
 DECLARE_MKX_UINTEGER(KaxTrackDefaultDuration)

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -225,8 +225,8 @@ DEFINE_SEMANTIC_ITEM(false, true, KaxFlagTextDescriptions)
 DEFINE_SEMANTIC_ITEM(false, true, KaxFlagOriginal)
 DEFINE_SEMANTIC_ITEM(false, true, KaxFlagCommentary)
 DEFINE_SEMANTIC_ITEM(true, true, KaxTrackFlagLacing)
-DEFINE_SEMANTIC_ITEM(true, true, KaxTrackMinCache)
-DEFINE_SEMANTIC_ITEM(false, true, KaxTrackMaxCache)
+DEFINE_SEMANTIC_ITEM(true, true, KaxTrackMinCache) // not supported
+DEFINE_SEMANTIC_ITEM(false, true, KaxTrackMaxCache) // not supported
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackDefaultDuration)
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackDefaultDecodedFieldDuration)
 DEFINE_SEMANTIC_ITEM(true, true, KaxTrackTimecodeScale)
@@ -828,6 +828,16 @@ filepos_t KaxReferenceTimeCode::RenderData(IOCallback & /* output */, bool /* bF
 }
 
 filepos_t KaxEncryptedBlock::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrackMinCache::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
+  assert(false); // no you are not allowed to use this element !
+  return 0;
+}
+
+filepos_t KaxTrackMaxCache::RenderData(IOCallback & /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {
   assert(false); // no you are not allowed to use this element !
   return 0;
 }


### PR DESCRIPTION
See https://github.com/ietf-wg-cellar/matroska-specification/pull/705

Don't think it qualifies as an API break since the method was already there.