### PR TITLE
allow only SeekID with a length of 4

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -49,7 +49,7 @@ using namespace libebml;
 namespace libmatroska {
 DECLARE_MKX_BINARY (KaxSeekID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() <= 4;}
+  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 4;}
 };
 
 DECLARE_MKX_UINTEGER(KaxSeekPosition)


### PR DESCRIPTION
As proposed in https://github.com/ietf-wg-cellar/matroska-specification/pull/731

@mbunkus can you check it has no negative effect ? So we can merge the change in the spec.