### PR TITLE
allow writing the upper signed VINT boundary

### DIFF
--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -131,13 +131,13 @@ static int SignedVINTLength(std::int64_t Value)
 {
   // prepare the head of the size (000...01xxxxxx)
   // optimal size
-  if (Value > SignedVINT_MIN(1) && Value < SignedVINT_MAX(1)) // 2^6
+  if (Value > SignedVINT_MIN(1) && Value <= SignedVINT_MAX(1)) // 2^6
     return 1;
-  if (Value > SignedVINT_MIN(2) && Value < SignedVINT_MAX(2)) // 2^13
+  if (Value > SignedVINT_MIN(2) && Value <= SignedVINT_MAX(2)) // 2^13
     return 2;
-  if (Value > SignedVINT_MIN(3) && Value < SignedVINT_MAX(3)) // 2^20
+  if (Value > SignedVINT_MIN(3) && Value <= SignedVINT_MAX(3)) // 2^20
     return 3;
-  if (Value > SignedVINT_MIN(4) && Value < SignedVINT_MAX(4)) // 2^27
+  if (Value > SignedVINT_MIN(4) && Value <= SignedVINT_MAX(4)) // 2^27
     return 4;
   return 5; // not really handled
 }


### PR DESCRIPTION
We should have no problem reading them in older version of libmatroska (rather libebml).

Draft on top of #105.

@mbunkus can you check this is working for you, so we can merge https://github.com/ietf-wg-cellar/matroska-specification/pull/733