### PR TITLE
include <new> when std::nothrow is used

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -61,22 +61,7 @@ class MATROSKA_DLL_API DataBuffer {
     bool     bInternalBuffer;
 
   public:
-    DataBuffer(binary * aBuffer, std::uint32_t aSize, bool (*aFreeBuffer)(const DataBuffer & aBuffer) = nullptr, bool _bInternalBuffer = false)
-      :mySize(aSize)
-      ,myFreeBuffer(aFreeBuffer)
-      ,bInternalBuffer(_bInternalBuffer)
-    {
-      if (bInternalBuffer)
-      {
-        myBuffer = new (std::nothrow) binary[mySize];
-        if (!myBuffer)
-          bValidValue = false;
-        else
-          memcpy(myBuffer, aBuffer, mySize);
-      }
-      else
-        myBuffer = aBuffer;
-    }
+    DataBuffer(binary * aBuffer, std::uint32_t aSize, bool (*aFreeBuffer)(const DataBuffer & aBuffer) = nullptr, bool _bInternalBuffer = false);
 
     virtual ~DataBuffer() = default;
     virtual binary * Buffer() {assert(bValidValue); return myBuffer;}

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -45,6 +45,23 @@
 
 namespace libmatroska {
 
+DataBuffer::DataBuffer(binary * aBuffer, std::uint32_t aSize, bool (*aFreeBuffer)(const DataBuffer & aBuffer), bool _bInternalBuffer)
+  :mySize(aSize)
+  ,myFreeBuffer(aFreeBuffer)
+  ,bInternalBuffer(_bInternalBuffer)
+{
+  if (bInternalBuffer)
+  {
+    myBuffer = new (std::nothrow) binary[mySize];
+    if (!myBuffer)
+      bValidValue = false;
+    else
+      memcpy(myBuffer, aBuffer, mySize);
+  }
+  else
+    myBuffer = aBuffer;
+}
+
 DataBuffer * DataBuffer::Clone()
 {
   auto ClonedData = static_cast<binary *>(malloc(mySize * sizeof(binary)));


### PR DESCRIPTION
I get errors like this in MSVC:
> include\matroska/KaxBlock.h(71,30): error C2061: syntax error: identifier 'nothrow'

Not sure why it works on other compilers. The nothrow was added in ff6e0db2fe677bbd62dcdc4c9ec13e2054c5f0c7 and worked so far. We don't have any other `<new>` include elsewhere. But it [should be included](https://en.cppreference.com/w/cpp/memory/new/nothrow).