### PR TITLE
[1.x] catch the DataBuffer allocation failure

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -68,11 +68,12 @@ class MATROSKA_DLL_API DataBuffer {
     {
       if (bInternalBuffer)
       {
-        myBuffer = new (std::nothrow) binary[mySize];
-        if (myBuffer == nullptr)
-          bValidValue = false;
-        else
+        try {
+          myBuffer = new binary[mySize];
           memcpy(myBuffer, aBuffer, mySize);
+        } catch (const std::bad_alloc &) {
+          bValidValue = false;
+        }
       }
       else
         myBuffer = aBuffer;


### PR DESCRIPTION
Using `std::nothrow` in a header risks breaking when included from a project that defines `new` to a different signature.

For example projects using a special version of new on Windows to detect memory leaks: https://learn.microsoft.com/en-us/cpp/c-runtime-library/find-memory-leaks-using-the-crt-library

(cherry picked from 16f06258157c9df4b521a6af49db45b1ea93cec0)

Backport of #108 into the 1.x branch