### PR TITLE
remove use of legacy libebml macros

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -205,7 +205,7 @@ DECLARE_MKX_MASTER(KaxBlockGroup)
 
 class MATROSKA_DLL_API KaxInternalBlock : public EbmlBinary {
   public:
-    KaxInternalBlock(EBML_DEF_CONS EBML_DEF_SEP bool bSimple EBML_DEF_SEP EBML_EXTRA_PARAM) :EBML_DEF_BINARY_INIT EBML_DEF_SEP bIsSimple(bSimple)
+    KaxInternalBlock(bool bSimple) :bIsSimple(bSimple)
     {}
     KaxInternalBlock(const KaxInternalBlock & ElementToClone);
     ~KaxInternalBlock() override;
@@ -292,14 +292,14 @@ class MATROSKA_DLL_API KaxInternalBlock : public EbmlBinary {
 DECLARE_MKX_CONTEXT(KaxBlock)
 class MATROSKA_DLL_API KaxBlock : public KaxInternalBlock {
   public:
-    KaxBlock(EBML_EXTRA_PARAM) :KaxInternalBlock(EBML_DEF_BINARY_CTX(KaxBlock)EBML_DEF_SEP false EBML_DEF_SEP EBML_EXTRA_CALL) {}
+    KaxBlock() :KaxInternalBlock(false) {}
         EBML_CONCRETE_CLASS(KaxBlock)
 };
 
 DECLARE_MKX_CONTEXT(KaxSimpleBlock)
 class MATROSKA_DLL_API KaxSimpleBlock : public KaxInternalBlock {
   public:
-    KaxSimpleBlock(EBML_EXTRA_PARAM) :KaxInternalBlock(EBML_DEF_BINARY_CTX(KaxSimpleBlock)EBML_DEF_SEP true EBML_DEF_SEP EBML_EXTRA_CALL) {}
+    KaxSimpleBlock() :KaxInternalBlock(true) {}
 
     void SetKeyframe(bool b_keyframe) { bIsKeyframe = b_keyframe; }
     void SetDiscardable(bool b_discard) { bIsDiscardable = b_discard; }

--- a/matroska/KaxDefines.h
+++ b/matroska/KaxDefines.h
@@ -59,67 +59,67 @@
 
 #define DECLARE_MKX_MASTER(x)     DECLARE_MKX_CONTEXT(x) \
 class MATROSKA_DLL_API x : public EbmlMaster { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlMaster(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_MASTER_CONS(x)     DECLARE_MKX_CONTEXT(x) \
 class MATROSKA_DLL_API x : public EbmlMaster { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone); \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_BINARY(x)     DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlBinary { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlBinary(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_BINARY_CONS(x) DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlBinary { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone); \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_UNISTRING(x)  DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlUnicodeString { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlUnicodeString(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_STRING(x)     DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlString { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlString(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_UINTEGER(x)   DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlUInteger { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlUInteger(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_SINTEGER_CONS(x)   DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlSInteger { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone); \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_SINTEGER(x)   DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlSInteger { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlSInteger(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_DATE(x)       DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlDate { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlDate(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_FLOAT(x)      DECLARE_MKX_CONTEXT(x) \
   class MATROSKA_DLL_API x : public EbmlFloat { \
-    public: x(EBML_EXTRA_PARAM); \
+    public: x(); \
     x(const x & ElementToClone) :EbmlFloat(ElementToClone) {} \
     EBML_CONCRETE_CLASS(x)
 

--- a/matroska/KaxInfoData.h
+++ b/matroska/KaxInfoData.h
@@ -53,7 +53,7 @@ namespace libmatroska {
 DECLARE_MKX_CONTEXT(KaxPrevUID)
 class MATROSKA_DLL_API KaxPrevUID : public KaxSegmentUID {
   public:
-    KaxPrevUID(EBML_EXTRA_PARAM) = default;
+    KaxPrevUID() = default;
     KaxPrevUID(const KaxPrevUID & ElementToClone) = default;
     bool ValidateSize() const override { return IsFiniteSize() && (GetSize() == 16);}
 
@@ -63,7 +63,7 @@ class MATROSKA_DLL_API KaxPrevUID : public KaxSegmentUID {
 DECLARE_MKX_CONTEXT(KaxNextUID)
 class MATROSKA_DLL_API KaxNextUID : public KaxSegmentUID {
   public:
-    KaxNextUID(EBML_EXTRA_PARAM) = default;
+    KaxNextUID() = default;
     KaxNextUID(const KaxNextUID & ElementToClone) = default;
     bool ValidateSize() const override { return IsFiniteSize() && (GetSize() == 16);}
 

--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -61,7 +61,7 @@ DECLARE_MKX_MASTER(KaxInfo)
 DECLARE_MKX_BINARY (KaxSegmentUID)
 #if defined(HAVE_EBML2) || defined(HAS_EBML2)
 public:
-  KaxSegmentUID(EBML_DEF_CONS EBML_DEF_SEP EBML_EXTRA_PARAM);
+  KaxSegmentUID();
 #endif
 public:
   bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}

--- a/src/KaxAttached.cpp
+++ b/src/KaxAttached.cpp
@@ -41,8 +41,8 @@ using namespace libebml;
 
 namespace libmatroska {
 
-KaxAttached::KaxAttached(EBML_EXTRA_DEF)
-  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxAttached) EBML_DEF_SEP EBML_EXTRA_CALL)
+KaxAttached::KaxAttached()
+  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxAttached))
 {
   SetSizeLength(2); // mandatory min size support (for easier updating) (2^(7*2)-2 = 16Ko)
 }

--- a/src/KaxAttachments.cpp
+++ b/src/KaxAttachments.cpp
@@ -40,8 +40,8 @@ using namespace libebml;
 // sub elements
 namespace libmatroska {
 
-KaxAttachments::KaxAttachments(EBML_EXTRA_DEF)
-  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxAttachments) EBML_DEF_SEP EBML_EXTRA_CALL)
+KaxAttachments::KaxAttachments()
+  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxAttachments))
 {
   SetSizeLength(2); // mandatory min size support (for easier updating) (2^(7*2)-2 = 16Ko)
 }

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -94,8 +94,8 @@ KaxInternalBlock::KaxInternalBlock(const KaxInternalBlock & ElementToClone)
   //NOTE("KaxBlockGroup::~KaxBlockGroup");
 } */
 
-KaxBlockGroup::KaxBlockGroup(EBML_EXTRA_DEF)
-  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxBlockGroup) EBML_DEF_SEP EBML_EXTRA_CALL)
+KaxBlockGroup::KaxBlockGroup()
+  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxBlockGroup))
 {}
 
 static constexpr std::int64_t SignedVINT_Shift1 = (1 << ((7*1) - 1)) - 1;
@@ -291,7 +291,7 @@ KaxBlockVirtual::KaxBlockVirtual(const KaxBlockVirtual & ElementToClone)
   SetValueIsSet(false);
 }
 
-KaxBlockVirtual::KaxBlockVirtual(EBML_EXTRA_DEF)
+KaxBlockVirtual::KaxBlockVirtual()
 {
   SetBuffer(DataBlock,sizeof(DataBlock));
   SetValueIsSet(false);

--- a/src/KaxBlockData.cpp
+++ b/src/KaxBlockData.cpp
@@ -47,7 +47,7 @@ const KaxBlockBlob & KaxReferenceBlock::RefBlock() const
   return *RefdBlock;
 }
 
-KaxReferenceBlock::KaxReferenceBlock(EBML_EXTRA_DEF)
+KaxReferenceBlock::KaxReferenceBlock()
 {
   bTimecodeSet = false;
 }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -38,8 +38,8 @@
 // sub elements
 namespace libmatroska {
 
-KaxCluster::KaxCluster(EBML_EXTRA_DEF)
-  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxCluster) EBML_DEF_SEP EBML_EXTRA_CALL)
+KaxCluster::KaxCluster()
+  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxCluster))
 {}
 
 KaxCluster::KaxCluster(const KaxCluster & ElementToClone)

--- a/src/KaxInfoData.cpp
+++ b/src/KaxInfoData.cpp
@@ -40,8 +40,8 @@
 namespace libmatroska {
 
 #if defined(HAVE_EBML2) || defined(HAS_EBML2)
-KaxSegmentUID::KaxSegmentUID(EBML_DEF_CONS EBML_DEF_SEP EBML_EXTRA_DEF)
-  :EbmlBinary(EBML_DEF_PARAM EBML_DEF_SEP EBML_EXTRA_CALL)
+KaxSegmentUID::KaxSegmentUID()
+  :EbmlBinary(EBML_DEF_PARAM)
 {
 }
 #endif

--- a/src/KaxSegment.cpp
+++ b/src/KaxSegment.cpp
@@ -44,8 +44,8 @@
 
 namespace libmatroska {
 
-KaxSegment::KaxSegment(EBML_EXTRA_DEF)
-  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxSegment) EBML_DEF_SEP EBML_EXTRA_CALL)
+KaxSegment::KaxSegment()
+  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxSegment))
 {
   SetSizeLength(5); // mandatory min size support (for easier updating) (2^(7*5)-2 = 32Go)
   SetSizeInfinite(); // by default a segment is big and the size is unknown in advance

--- a/src/KaxTracks.cpp
+++ b/src/KaxTracks.cpp
@@ -39,8 +39,8 @@
 
 namespace libmatroska {
 
-KaxTrackEntry::KaxTrackEntry(EBML_EXTRA_DEF)
-  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxTrackEntry) EBML_DEF_SEP EBML_EXTRA_CALL)
+KaxTrackEntry::KaxTrackEntry()
+  :EbmlMaster(EBML_CLASS_SEMCONTEXT(KaxTrackEntry))
 {}
 
 void KaxTrackEntry::EnableLacing(bool bEnable)


### PR DESCRIPTION
They are now removed and were doing nothing.