### PR TITLE
Use a SPDX header for the LGPL 2.1 license

### DIFF
--- a/matroska/FileKax.h
+++ b/matroska/FileKax.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxBlockData.h
+++ b/matroska/KaxBlockData.h
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxConfig.h
+++ b/matroska/KaxConfig.h
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxContexts.h
+++ b/matroska/KaxContexts.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxCuesData.h
+++ b/matroska/KaxCuesData.h
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxDefines.h
+++ b/matroska/KaxDefines.h
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxInfoData.h
+++ b/matroska/KaxInfoData.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxSeekHead.h
+++ b/matroska/KaxSeekHead.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxSegment.h
+++ b/matroska/KaxSegment.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class MATROSKA_DLL_API description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -1,32 +1,9 @@
+// Copyright © 2002-2020 Matroska (non-profit organisation).
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /**********************************************************************
-**  DO NOT EDIT, GENERATED WITH DATA2LIB
+**  DO NOT EDIT, GENERATED WITH schema_2_kaxsemantic_h.xsl
 **  https://github.com/Matroska-Org/foundation-source/tree/master/spectool
-**
-**  libmatroska : parse Matroska files, see https://www.matroska.org/
-**
-**  Copyright (c) 2002-2022, Matroska (non-profit organisation)
-**  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
 **********************************************************************/
 
 
@@ -61,7 +38,7 @@ DECLARE_MKX_MASTER(KaxInfo)
 DECLARE_MKX_BINARY (KaxSegmentUID)
 #if defined(HAVE_EBML2) || defined(HAS_EBML2)
 public:
-  KaxSegmentUID();
+  KaxSegmentUID(EBML_DEF_CONS EBML_DEF_SEP EBML_EXTRA_PARAM);
 #endif
 public:
   bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}

--- a/matroska/KaxTracks.h
+++ b/matroska/KaxTracks.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxTypes.h
+++ b/matroska/KaxTypes.h
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/matroska/KaxVersion.h
+++ b/matroska/KaxVersion.h
@@ -1,29 +1,5 @@
-/****************************************************************************
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/FileKax.cpp
+++ b/src/FileKax.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2003 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2003 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file

--- a/src/KaxAttached.cpp
+++ b/src/KaxAttached.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxAttachments.cpp
+++ b/src/KaxAttachments.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxBlockData.cpp
+++ b/src/KaxBlockData.cpp
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxContexts.cpp
+++ b/src/KaxContexts.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxInfoData.cpp
+++ b/src/KaxInfoData.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxSeekHead.cpp
+++ b/src/KaxSeekHead.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxSegment.cpp
+++ b/src/KaxSegment.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -1,32 +1,9 @@
+// Copyright © 2002-2020 Matroska (non-profit organisation).
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /**********************************************************************
 **  DO NOT EDIT, GENERATED WITH schema_2_kaxsemantic_cpp.xsl
 **  https://github.com/Matroska-Org/foundation-source/tree/master/spectool
-**
-**  libmatroska : parse Matroska files, see https://www.matroska.org/
-**
-**  Copyright (c) 2002-2020, Matroska (non-profit organisation)
-**  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
 **********************************************************************/
 
 #include "matroska/KaxContexts.h"

--- a/src/KaxTracks.cpp
+++ b/src/KaxTracks.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/src/KaxVersion.cpp
+++ b/src/KaxVersion.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2010 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2010 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
   \file

--- a/test/ebml/test0.cpp
+++ b/test/ebml/test0.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file

--- a/test/ebml/test00.cpp
+++ b/test/ebml/test00.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file

--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -1,29 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Steve Lhomme.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file

--- a/test/tags/test9.cpp
+++ b/test/tags/test9.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Moritz Bunkus.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Moritz Bunkus.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file

--- a/test/utf8/test5.cpp
+++ b/test/utf8/test5.cpp
@@ -1,31 +1,5 @@
-/****************************************************************************
-** libmatroska : parse Matroska files, see http://www.matroska.org/
-**
-** <file/class description>
-**
-** Copyright (C) 2002-2004 Steve Lhomme.  All rights reserved.
-**
-** This file is part of libmatroska.
-**
-** This library is free software; you can redistribute it and/or
-** modify it under the terms of the GNU Lesser General Public
-** License as published by the Free Software Foundation; either
-** version 2.1 of the License, or (at your option) any later version.
-**
-** This library is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-** Lesser General Public License for more details.
-**
-** You should have received a copy of the GNU Lesser General Public
-** License along with this library; if not, write to the Free Software
-** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-**
-** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
-** Contact license@matroska.org if any conditions of this licensing are
-** not clear to you.
-**
-**********************************************************************/
+// Copyright © 2002-2004 Moritz Bunkus.
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 /*!
     \file


### PR DESCRIPTION
The copyright date and holder are kept as-is.