### PR TITLE
bump version number to 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 
-project(matroska VERSION 1.8.0)
+project(matroska VERSION 2.0.0)
 
 option(DISABLE_PKGCONFIG "Disable PkgConfig module generation" OFF)
 option(DISABLE_CMAKE_CONFIG "Disable CMake package config module generation" OFF)

--- a/matroska/KaxVersion.h
+++ b/matroska/KaxVersion.h
@@ -15,7 +15,7 @@
 
 namespace libmatroska {
 
-#define LIBMATROSKA_VERSION 0x010800
+#define LIBMATROSKA_VERSION 0x020000
 
 extern const MATROSKA_DLL_API std::string KaxCodeVersion;
 extern const MATROSKA_DLL_API std::string KaxCodeDate;

--- a/src/KaxVersion.cpp
+++ b/src/KaxVersion.cpp
@@ -10,7 +10,7 @@
 
 namespace libmatroska {
 
-const std::string KaxCodeVersion = "1.8.0";
+const std::string KaxCodeVersion = "2.0.0";
 
 // Up to version 1.4.4 this library exported a build date string. As
 // this made the build non-reproducible, replace it by a placeholder to


### PR DESCRIPTION
libEBML has already been bumped to v2. Additionally I need the `#define` to be set properly for conditional compilation due to the removal of `KaxInfoData.h` (need to include it in < v2, otherwise `KaxNext/PrevUid` isn't defined, have to include `KaxSemantic.h` in ≥ v2).