### PR TITLE
use the proper name for the EbmlHead semantic context

### DIFF
--- a/test/ebml/test00.cpp
+++ b/test/ebml/test00.cpp
@@ -127,7 +127,7 @@ int main(void)
     }
     printf("\n");
 
-    ElementLevel0->SkipData(aStream, EbmlHead_Context);
+    ElementLevel0->SkipData(aStream, Context_EbmlHead);
     if (ElementLevel0 != NULL)
       delete ElementLevel0;
   }

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
     }
     printf("\n");
 
-    ElementLevel0->SkipData(aStream, EbmlHead_Context);
+    ElementLevel0->SkipData(aStream, Context_EbmlHead);
     if (ElementLevel0 != NULL)
       delete ElementLevel0;
   }


### PR DESCRIPTION
It was using a defined name rather than the real name.