### PR TITLE
Rename "timecode" variables to "timestamp"

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -251,7 +251,7 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
     std::vector<std::int32_t> SizeList;
     std::uint64_t             Timestamp; // temporary timestamp of the first frame, non scaled
     std::int16_t              LocalTimestamp;
-    bool                      bLocalTimecodeUsed{false};
+    bool                      bLocalTimestampUsed{false};
     std::uint16_t               TrackNumber;
     LacingType                mLacing{LACING_AUTO};
     bool                      mInvisible{false};

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -244,13 +244,13 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
      * \return Get the timestamp as written in the Block (not scaled).
      * \since LIBMATROSKA_VERSION >= 0x010700
      */
-    std::int16_t GetRelativeTimestamp() const { return LocalTimecode; }
+    std::int16_t GetRelativeTimestamp() const { return LocalTimestamp; }
 
   protected:
     std::vector<DataBuffer *> myBuffers;
     std::vector<std::int32_t> SizeList;
     std::uint64_t             Timestamp; // temporary timestamp of the first frame, non scaled
-    std::int16_t              LocalTimecode;
+    std::int16_t              LocalTimestamp;
     bool                      bLocalTimecodeUsed{false};
     std::uint16_t               TrackNumber;
     LacingType                mLacing{LACING_AUTO};

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -191,7 +191,7 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
     /*!
       \todo !!!! This method needs to be changes !
     */
-    std::uint64_t GlobalTimecode() const {return Timecode;}
+    std::uint64_t GlobalTimecode() const {return Timestamp;}
 
     /*!
       \note override this function to generate the Data/Size on the fly, unlike the usual binary elements
@@ -249,7 +249,7 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
   protected:
     std::vector<DataBuffer *> myBuffers;
     std::vector<std::int32_t> SizeList;
-    std::uint64_t             Timecode; // temporary timecode of the first frame, non scaled
+    std::uint64_t             Timestamp; // temporary timestamp of the first frame, non scaled
     std::int16_t              LocalTimecode;
     bool                      bLocalTimecodeUsed{false};
     std::uint16_t               TrackNumber;
@@ -341,7 +341,7 @@ DECLARE_MKX_BINARY_CONS(KaxBlockVirtual)
     libebml::filepos_t ReadData(libebml::IOCallback & input, libebml::ScopeMode ReadFully = libebml::SCOPE_ALL_DATA) override;
 
   protected:
-    std::uint64_t Timecode; // temporary timecode of the first frame if there are more than one
+    std::uint64_t Timestamp; // temporary timestamp of the first frame if there are more than one
     std::uint16_t TrackNumber;
     libebml::binary DataBlock[5];
 

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -145,7 +145,7 @@ DECLARE_MKX_MASTER(KaxBlockGroup)
     bool GetBlockDuration(std::uint64_t &TheTimecode) const;
 
     /*!
-      \return the global timecode of this Block (not just the delta to the Cluster)
+      \return the global timestamp of this Block (not just the delta to the Cluster)
     */
     std::uint64_t GlobalTimecode() const;
     std::uint64_t GlobalTimecodeScale() const {

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -120,17 +120,17 @@ DECLARE_MKX_MASTER(KaxBlockGroup)
     /*!
       \brief Addition of a frame without references
     */
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, LacingType lacing = LACING_AUTO);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, LacingType lacing = LACING_AUTO);
     /*!
       \brief Addition of a frame with a backward reference (P frame)
     */
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, const KaxBlockGroup & PastBlock, LacingType lacing = LACING_AUTO);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, const KaxBlockGroup & PastBlock, LacingType lacing = LACING_AUTO);
 
     /*!
       \brief Addition of a frame with a backward+forward reference (B frame)
     */
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, const KaxBlockGroup & PastBlock, const KaxBlockGroup & ForwBlock, LacingType lacing = LACING_AUTO);
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, const KaxBlockBlob * PastBlock, const KaxBlockBlob * ForwBlock, LacingType lacing = LACING_AUTO);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, const KaxBlockGroup & PastBlock, const KaxBlockGroup & ForwBlock, LacingType lacing = LACING_AUTO);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, const KaxBlockBlob * PastBlock, const KaxBlockBlob * ForwBlock, LacingType lacing = LACING_AUTO);
 
     void SetParent(KaxCluster & aParentCluster);
 
@@ -208,7 +208,7 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
     unsigned int NumberFrames() const { return SizeList.size();}
     DataBuffer & GetBuffer(unsigned int iIndex) {return *myBuffers[iIndex];}
 
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, LacingType lacing = LACING_AUTO, bool invisible = false);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, LacingType lacing = LACING_AUTO, bool invisible = false);
 
     /*!
       \brief release all the frames of all Blocks
@@ -310,7 +310,7 @@ public:
   void SetBlockDuration(std::uint64_t TimeLength);
 
   void SetParent(KaxCluster & aParentCluster);
-  bool AddFrameAuto(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, LacingType lacing = LACING_AUTO, const KaxBlockBlob * PastBlock = nullptr, const KaxBlockBlob * ForwBlock = nullptr);
+  bool AddFrameAuto(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, LacingType lacing = LACING_AUTO, const KaxBlockBlob * PastBlock = nullptr, const KaxBlockBlob * ForwBlock = nullptr);
 
   bool IsSimpleBlock() const {return bUseSimpleBlock;}
 

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -142,7 +142,7 @@ DECLARE_MKX_MASTER(KaxBlockGroup)
       \brief Set the duration of the contained frame(s) (for the total number of frames)
     */
     void SetBlockDuration(std::uint64_t TimeLength);
-    bool GetBlockDuration(std::uint64_t &TheTimecode) const;
+    bool GetBlockDuration(std::uint64_t &TheTimestamp) const;
 
     /*!
       \return the global timestamp of this Block (not just the delta to the Cluster)

--- a/matroska/KaxBlockData.h
+++ b/matroska/KaxBlockData.h
@@ -24,7 +24,7 @@ DECLARE_MKX_SINTEGER_CONS(KaxReferenceBlock)
   public:
         ~KaxReferenceBlock() override;
     /*!
-      \brief override this method to compute the timecode value
+      \brief override this method to compute the timestamp value
     */
     libebml::filepos_t UpdateSize(ShouldWrite writeFilter = WriteSkipDefault, bool bForceRender = false) override;
 

--- a/matroska/KaxBlockData.h
+++ b/matroska/KaxBlockData.h
@@ -32,7 +32,7 @@ DECLARE_MKX_SINTEGER_CONS(KaxReferenceBlock)
     void SetReferencedBlock(const KaxBlockBlob * aRefdBlock);
     void SetReferencedBlock(const KaxBlockGroup & aRefdBlock);
     void SetParentBlock(const KaxBlockGroup & aParentBlock) {ParentBlock = &aParentBlock;}
-    void SetReferencedTimecode(std::int64_t refTimecode) { SetValue(refTimecode); bTimestampSet = true;};
+    void SetReferencedTimecode(std::int64_t refTimestamp) { SetValue(refTimestamp); bTimestampSet = true;};
 
   protected:
     const KaxBlockBlob * RefdBlock{nullptr};

--- a/matroska/KaxBlockData.h
+++ b/matroska/KaxBlockData.h
@@ -32,12 +32,12 @@ DECLARE_MKX_SINTEGER_CONS(KaxReferenceBlock)
     void SetReferencedBlock(const KaxBlockBlob * aRefdBlock);
     void SetReferencedBlock(const KaxBlockGroup & aRefdBlock);
     void SetParentBlock(const KaxBlockGroup & aParentBlock) {ParentBlock = &aParentBlock;}
-    void SetReferencedTimecode(std::int64_t refTimecode) { SetValue(refTimecode); bTimecodeSet = true;};
+    void SetReferencedTimecode(std::int64_t refTimecode) { SetValue(refTimecode); bTimestampSet = true;};
 
   protected:
     const KaxBlockBlob * RefdBlock{nullptr};
     const KaxBlockGroup * ParentBlock{nullptr};
-    bool bTimecodeSet{false};
+    bool bTimestampSet{false};
         bool bOurBlob{false};
         void FreeBlob();
 };

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -68,18 +68,18 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     void SetParent(const KaxSegment & aParentSegment) {ParentSegment = &aParentSegment;}
 
-    void SetPreviousTimecode(std::uint64_t aPreviousTimecode, std::int64_t aTimecodeScale) {
+    void SetPreviousTimecode(std::uint64_t aPreviousTimecode, std::int64_t aTimestampScale) {
       bPreviousTimecodeIsSet = true;
       PreviousTimecode = aPreviousTimecode;
-      SetGlobalTimecodeScale(aTimecodeScale);
+      SetGlobalTimecodeScale(aTimestampScale);
     }
 
     /*!
       \note dirty hack to get the mandatory data back after reading
       \todo there should be a better way to get mandatory data
     */
-    void InitTimecode(std::uint64_t aTimecode, std::int64_t aTimecodeScale) {
-      SetGlobalTimecodeScale(aTimecodeScale);
+    void InitTimecode(std::uint64_t aTimecode, std::int64_t aTimestampScale) {
+      SetGlobalTimecodeScale(aTimestampScale);
       MinTimecode = MaxTimecode = PreviousTimecode = aTimecode * TimestampScale;
       bFirstFrameInside = bPreviousTimecodeIsSet = true;
     }

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -78,9 +78,9 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
       \note dirty hack to get the mandatory data back after reading
       \todo there should be a better way to get mandatory data
     */
-    void InitTimecode(std::uint64_t aTimecode, std::int64_t aTimestampScale) {
+    void InitTimecode(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
       SetGlobalTimecodeScale(aTimestampScale);
-      MinTimecode = MaxTimecode = PreviousTimecode = aTimecode * TimestampScale;
+      MinTimecode = MaxTimecode = PreviousTimecode = aTimestamp * TimestampScale;
       bFirstFrameInside = bPreviousTimecodeIsSet = true;
     }
 

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -69,7 +69,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     void SetParent(const KaxSegment & aParentSegment) {ParentSegment = &aParentSegment;}
 
     void SetPreviousTimecode(std::uint64_t aPreviousTimestamp, std::int64_t aTimestampScale) {
-      bPreviousTimecodeIsSet = true;
+      bPreviousTimestampIsSet = true;
       PreviousTimestamp = aPreviousTimestamp;
       SetGlobalTimecodeScale(aTimestampScale);
     }
@@ -81,7 +81,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     void InitTimecode(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
       SetGlobalTimecodeScale(aTimestampScale);
       MinTimecode = MaxTimecode = PreviousTimestamp = aTimestamp * TimestampScale;
-      bFirstFrameInside = bPreviousTimecodeIsSet = true;
+      bFirstFrameInside = bPreviousTimestampIsSet = true;
     }
 
     std::int16_t GetBlockLocalTimecode(std::uint64_t GlobalTimecode) const;
@@ -117,7 +117,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     std::int64_t  TimestampScale;
 
     bool   bFirstFrameInside{false}; // used to speed research
-    bool   bPreviousTimecodeIsSet{false};
+    bool   bPreviousTimestampIsSet{false};
     bool   bTimecodeScaleIsSet{false};
     bool   bSilentTracksUsed{false};
 

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -90,10 +90,10 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
       TimestampScale = aGlobalTimestampScale;
-      bTimecodeScaleIsSet = true;
+      bTimestampScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {
-      assert(bTimecodeScaleIsSet);
+      assert(bTimestampScaleIsSet);
       return TimestampScale;
     }
 
@@ -118,7 +118,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     bool   bFirstFrameInside{false}; // used to speed research
     bool   bPreviousTimestampIsSet{false};
-    bool   bTimecodeScaleIsSet{false};
+    bool   bTimestampScaleIsSet{false};
     bool   bSilentTracksUsed{false};
 
     /*!

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -80,7 +80,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     */
     void InitTimecode(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
       SetGlobalTimecodeScale(aTimestampScale);
-      MinTimecode = MaxTimestamp = PreviousTimestamp = aTimestamp * TimestampScale;
+      MinTimestamp = MaxTimestamp = PreviousTimestamp = aTimestamp * TimestampScale;
       bFirstFrameInside = bPreviousTimestampIsSet = true;
     }
 
@@ -113,7 +113,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     KaxBlockGroup    * currentNewBlock{nullptr};
     const KaxSegment * ParentSegment{nullptr};
 
-    std::uint64_t MinTimecode, MaxTimestamp, PreviousTimestamp;
+    std::uint64_t MinTimestamp, MaxTimestamp, PreviousTimestamp;
     std::int64_t  TimestampScale;
 
     bool   bFirstFrameInside{false}; // used to speed research

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -26,22 +26,22 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     /*!
       \brief Addition of a frame without references
 
-      \param timecode the timecode is expressed in nanoseconds, relative to the beggining of the Segment
+      \param timestamp the timestamp is expressed in nanoseconds, relative to the beggining of the Segment
     */
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, LacingType lacing = LACING_AUTO);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, LacingType lacing = LACING_AUTO);
     /*!
       \brief Addition of a frame with a backward reference (P frame)
-      \param timecode the timecode is expressed in nanoseconds, relative to the beggining of the Segment
+      \param timestamp the timestamp is expressed in nanoseconds, relative to the beggining of the Segment
 
     */
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, LacingType lacing = LACING_AUTO);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, LacingType lacing = LACING_AUTO);
 
     /*!
       \brief Addition of a frame with a backward+forward reference (B frame)
-      \param timecode the timecode is expressed in nanoseconds, relative to the beggining of the Segment
+      \param timestamp the timestamp is expressed in nanoseconds, relative to the beggining of the Segment
 
     */
-    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, const KaxBlockGroup & ForwBlock, LacingType lacing = LACING_AUTO);
+    bool AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, const KaxBlockGroup & ForwBlock, LacingType lacing = LACING_AUTO);
 
     /*!
       \brief Render the data to the stream and retrieve the position of BlockGroups for later cue entries
@@ -124,7 +124,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     /*!
       \note method used internally
     */
-    bool AddFrameInternal(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup * PastBlock, const KaxBlockGroup * ForwBlock, LacingType lacing);
+    bool AddFrameInternal(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup * PastBlock, const KaxBlockGroup * ForwBlock, LacingType lacing);
 };
 
 } // namespace libmatroska

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -70,7 +70,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     void SetPreviousTimecode(std::uint64_t aPreviousTimestamp, std::int64_t aTimestampScale) {
       bPreviousTimecodeIsSet = true;
-      PreviousTimecode = aPreviousTimestamp;
+      PreviousTimestamp = aPreviousTimestamp;
       SetGlobalTimecodeScale(aTimestampScale);
     }
 
@@ -80,7 +80,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     */
     void InitTimecode(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
       SetGlobalTimecodeScale(aTimestampScale);
-      MinTimecode = MaxTimecode = PreviousTimecode = aTimestamp * TimestampScale;
+      MinTimecode = MaxTimecode = PreviousTimestamp = aTimestamp * TimestampScale;
       bFirstFrameInside = bPreviousTimecodeIsSet = true;
     }
 
@@ -113,7 +113,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     KaxBlockGroup    * currentNewBlock{nullptr};
     const KaxSegment * ParentSegment{nullptr};
 
-    std::uint64_t MinTimecode, MaxTimecode, PreviousTimecode;
+    std::uint64_t MinTimecode, MaxTimecode, PreviousTimestamp;
     std::int64_t  TimestampScale;
 
     bool   bFirstFrameInside{false}; // used to speed research

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -88,8 +88,8 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     std::uint64_t GetBlockGlobalTimecode(std::int16_t LocalTimecode);
 
-    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimecodeScale) {
-      TimestampScale = aGlobalTimecodeScale;
+    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
+      TimestampScale = aGlobalTimestampScale;
       bTimecodeScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -68,9 +68,9 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     void SetParent(const KaxSegment & aParentSegment) {ParentSegment = &aParentSegment;}
 
-    void SetPreviousTimecode(std::uint64_t aPreviousTimecode, std::int64_t aTimestampScale) {
+    void SetPreviousTimecode(std::uint64_t aPreviousTimestamp, std::int64_t aTimestampScale) {
       bPreviousTimecodeIsSet = true;
-      PreviousTimecode = aPreviousTimecode;
+      PreviousTimecode = aPreviousTimestamp;
       SetGlobalTimecodeScale(aTimestampScale);
     }
 

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -86,7 +86,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     std::int16_t GetBlockLocalTimecode(std::uint64_t GlobalTimecode) const;
 
-    std::uint64_t GetBlockGlobalTimecode(std::int16_t LocalTimecode);
+    std::uint64_t GetBlockGlobalTimecode(std::int16_t LocalTimestamp);
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
       TimestampScale = aGlobalTimestampScale;

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -80,7 +80,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     */
     void InitTimecode(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
       SetGlobalTimecodeScale(aTimestampScale);
-      MinTimecode = MaxTimecode = PreviousTimestamp = aTimestamp * TimestampScale;
+      MinTimecode = MaxTimestamp = PreviousTimestamp = aTimestamp * TimestampScale;
       bFirstFrameInside = bPreviousTimestampIsSet = true;
     }
 
@@ -113,7 +113,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     KaxBlockGroup    * currentNewBlock{nullptr};
     const KaxSegment * ParentSegment{nullptr};
 
-    std::uint64_t MinTimecode, MaxTimecode, PreviousTimestamp;
+    std::uint64_t MinTimecode, MaxTimestamp, PreviousTimestamp;
     std::int64_t  TimestampScale;
 
     bool   bFirstFrameInside{false}; // used to speed research

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -49,7 +49,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     libebml::filepos_t Render(libebml::IOCallback & output, KaxCues & CueToUpdate, ShouldWrite writeFilter = WriteSkipDefault);
 
     /*!
-      \return the global timecode of this Cluster
+      \return the global timestamp of this Cluster
     */
     std::uint64_t GlobalTimecode() const;
 

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -80,7 +80,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     */
     void InitTimecode(std::uint64_t aTimecode, std::int64_t aTimecodeScale) {
       SetGlobalTimecodeScale(aTimecodeScale);
-      MinTimecode = MaxTimecode = PreviousTimecode = aTimecode * TimecodeScale;
+      MinTimecode = MaxTimecode = PreviousTimecode = aTimecode * TimestampScale;
       bFirstFrameInside = bPreviousTimecodeIsSet = true;
     }
 
@@ -89,12 +89,12 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     std::uint64_t GetBlockGlobalTimecode(std::int16_t LocalTimecode);
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimecodeScale) {
-      TimecodeScale = aGlobalTimecodeScale;
+      TimestampScale = aGlobalTimecodeScale;
       bTimecodeScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {
       assert(bTimecodeScaleIsSet);
-      return TimecodeScale;
+      return TimestampScale;
     }
 
     bool SetSilentTrackUsed()
@@ -114,7 +114,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     const KaxSegment * ParentSegment{nullptr};
 
     std::uint64_t MinTimecode, MaxTimecode, PreviousTimecode;
-    std::int64_t  TimecodeScale;
+    std::int64_t  TimestampScale;
 
     bool   bFirstFrameInside{false}; // used to speed research
     bool   bPreviousTimecodeIsSet{false};

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -43,18 +43,18 @@ DECLARE_MKX_MASTER(KaxCues)
     const KaxCuePoint * GetTimecodePoint(std::uint64_t aTimestamp) const;
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
-      mGlobalTimecodeScale = aGlobalTimestampScale;
+      mGlobalTimestampScale = aGlobalTimestampScale;
       bGlobalTimecodeScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {
       assert(bGlobalTimecodeScaleIsSet);
-      return mGlobalTimecodeScale;
+      return mGlobalTimestampScale;
     }
 
   protected:
     std::vector<const KaxBlockBlob *> myTempReferences;
     bool   bGlobalTimecodeScaleIsSet;
-    std::uint64_t mGlobalTimecodeScale;
+    std::uint64_t mGlobalTimestampScale;
 };
 
 } // namespace libmatroska

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -32,7 +32,7 @@ DECLARE_MKX_MASTER(KaxCues)
     void PositionSet(const KaxBlockBlob & BlockReference);
 
     /*!
-      \brief override to sort by timecode/track
+      \brief override to sort by timestamp/track
     */
     libebml::filepos_t Render(libebml::IOCallback & output, ShouldWrite writeFilter = WriteSkipDefault) {
       Sort();

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -39,8 +39,8 @@ DECLARE_MKX_MASTER(KaxCues)
       return EbmlMaster::Render(output, writeFilter);
     }
 
-    std::uint64_t GetTimecodePosition(std::uint64_t aTimecode) const;
-    const KaxCuePoint * GetTimecodePoint(std::uint64_t aTimecode) const;
+    std::uint64_t GetTimecodePosition(std::uint64_t aTimestamp) const;
+    const KaxCuePoint * GetTimecodePoint(std::uint64_t aTimestamp) const;
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
       mGlobalTimecodeScale = aGlobalTimestampScale;

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -42,8 +42,8 @@ DECLARE_MKX_MASTER(KaxCues)
     std::uint64_t GetTimecodePosition(std::uint64_t aTimecode) const;
     const KaxCuePoint * GetTimecodePoint(std::uint64_t aTimecode) const;
 
-    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimecodeScale) {
-      mGlobalTimecodeScale = aGlobalTimecodeScale;
+    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
+      mGlobalTimecodeScale = aGlobalTimestampScale;
       bGlobalTimecodeScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -44,16 +44,16 @@ DECLARE_MKX_MASTER(KaxCues)
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
       mGlobalTimestampScale = aGlobalTimestampScale;
-      bGlobalTimecodeScaleIsSet = true;
+      bGlobalTimestampScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {
-      assert(bGlobalTimecodeScaleIsSet);
+      assert(bGlobalTimestampScaleIsSet);
       return mGlobalTimestampScale;
     }
 
   protected:
     std::vector<const KaxBlockBlob *> myTempReferences;
-    bool   bGlobalTimecodeScaleIsSet;
+    bool   bGlobalTimestampScaleIsSet;
     std::uint64_t mGlobalTimestampScale;
 };
 

--- a/matroska/KaxCuesData.h
+++ b/matroska/KaxCuesData.h
@@ -23,15 +23,15 @@ class KaxSimpleBlock;
 
 DECLARE_MKX_MASTER(KaxCuePoint)
   public:
-    void PositionSet(const KaxBlockGroup & BlockReference, std::uint64_t GlobalTimecodeScale);
-    void PositionSet(const KaxBlockBlob & BlobReference, std::uint64_t GlobalTimecodeScale);
-    void PositionSet(const KaxSimpleBlock & BlockReference, std::uint64_t GlobalTimecodeScale);
-    void PositionSet(const KaxInternalBlock & BlockReference, const KaxBlockGroup *BlockGroup, std::uint64_t GlobalTimecodeScale);
+    void PositionSet(const KaxBlockGroup & BlockReference, std::uint64_t GlobalTimestampScale);
+    void PositionSet(const KaxBlockBlob & BlobReference, std::uint64_t GlobalTimestampScale);
+    void PositionSet(const KaxSimpleBlock & BlockReference, std::uint64_t GlobalTimestampScale);
+    void PositionSet(const KaxInternalBlock & BlockReference, const KaxBlockGroup *BlockGroup, std::uint64_t GlobalTimestampScale);
 
     bool IsSmallerThan(const EbmlElement *Cmp) const override;
 
     const KaxCueTrackPositions * GetSeekPosition() const;
-    bool Timecode(std::uint64_t & aTimecode, std::uint64_t GlobalTimecodeScale) const;
+    bool Timecode(std::uint64_t & aTimecode, std::uint64_t GlobalTimestampScale) const;
 };
 
 DECLARE_MKX_MASTER(KaxCueTrackPositions)
@@ -42,8 +42,8 @@ DECLARE_MKX_MASTER(KaxCueTrackPositions)
 
 DECLARE_MKX_MASTER(KaxCueReference)
   public:
-    void AddReference(const KaxBlockGroup & BlockReferenced, std::uint64_t GlobalTimecodeScale);
-    void AddReference(const KaxBlockBlob & BlockReferenced, std::uint64_t GlobalTimecodeScale);
+    void AddReference(const KaxBlockGroup & BlockReferenced, std::uint64_t GlobalTimestampScale);
+    void AddReference(const KaxBlockBlob & BlockReferenced, std::uint64_t GlobalTimestampScale);
 };
 
 } // namespace libmatroska

--- a/matroska/KaxCuesData.h
+++ b/matroska/KaxCuesData.h
@@ -31,7 +31,7 @@ DECLARE_MKX_MASTER(KaxCuePoint)
     bool IsSmallerThan(const EbmlElement *Cmp) const override;
 
     const KaxCueTrackPositions * GetSeekPosition() const;
-    bool Timecode(std::uint64_t & aTimecode, std::uint64_t GlobalTimestampScale) const;
+    bool Timecode(std::uint64_t & aTimestamp, std::uint64_t GlobalTimestampScale) const;
 };
 
 DECLARE_MKX_MASTER(KaxCueTrackPositions)

--- a/matroska/KaxTracks.h
+++ b/matroska/KaxTracks.h
@@ -32,15 +32,15 @@ DECLARE_MKX_MASTER(KaxTrackEntry)
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
       mGlobalTimestampScale = aGlobalTimestampScale;
-      bGlobalTimecodeScaleIsSet = true;
+      bGlobalTimestampScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {
-      assert(bGlobalTimecodeScaleIsSet);
+      assert(bGlobalTimestampScaleIsSet);
       return mGlobalTimestampScale;
     }
 
   protected:
-    bool   bGlobalTimecodeScaleIsSet{false};
+    bool   bGlobalTimestampScaleIsSet{false};
     std::uint64_t mGlobalTimestampScale;
 };
 

--- a/matroska/KaxTracks.h
+++ b/matroska/KaxTracks.h
@@ -30,8 +30,8 @@ DECLARE_MKX_MASTER(KaxTrackEntry)
       return(!myLacing || (static_cast<std::uint8_t>(*myLacing) != 0));
     }
 
-    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimecodeScale) {
-      mGlobalTimecodeScale = aGlobalTimecodeScale;
+    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
+      mGlobalTimecodeScale = aGlobalTimestampScale;
       bGlobalTimecodeScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {

--- a/matroska/KaxTracks.h
+++ b/matroska/KaxTracks.h
@@ -31,17 +31,17 @@ DECLARE_MKX_MASTER(KaxTrackEntry)
     }
 
     void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
-      mGlobalTimecodeScale = aGlobalTimestampScale;
+      mGlobalTimestampScale = aGlobalTimestampScale;
       bGlobalTimecodeScaleIsSet = true;
     }
     std::uint64_t GlobalTimecodeScale() const {
       assert(bGlobalTimecodeScaleIsSet);
-      return mGlobalTimecodeScale;
+      return mGlobalTimestampScale;
     }
 
   protected:
     bool   bGlobalTimecodeScaleIsSet{false};
-    std::uint64_t mGlobalTimecodeScale;
+    std::uint64_t mGlobalTimestampScale;
 };
 
 } // namespace libmatroska

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -55,7 +55,7 @@ KaxInternalBlock::~KaxInternalBlock()
 KaxInternalBlock::KaxInternalBlock(const KaxInternalBlock & ElementToClone)
   :EbmlBinary(ElementToClone)
   ,Timestamp(ElementToClone.Timestamp)
-  ,LocalTimecode(ElementToClone.LocalTimecode)
+  ,LocalTimestamp(ElementToClone.LocalTimestamp)
   ,bLocalTimecodeUsed(ElementToClone.bLocalTimecodeUsed)
   ,TrackNumber(ElementToClone.TrackNumber)
   ,ParentCluster(ElementToClone.ParentCluster) ///< \todo not exactly
@@ -517,7 +517,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
         TrackNumber &= 0x7F;
       }
 
-      LocalTimecode = static_cast<std::int16_t>(Mem.GetUInt16BE());
+      LocalTimestamp = static_cast<std::int16_t>(Mem.GetUInt16BE());
       bLocalTimecodeUsed = true;
 
       const std::uint8_t Flags = Mem.GetUInt8();
@@ -642,7 +642,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
         TrackNumber &= 0x7F;
       }
 
-      LocalTimecode = endian::from_big16(cursor);
+      LocalTimestamp = endian::from_big16(cursor);
       bLocalTimecodeUsed = true;
       cursor += 2;
 
@@ -748,7 +748,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
     myBuffers.clear();
     SizeList.clear();
     Timestamp          = 0;
-    LocalTimecode      = 0;
+    LocalTimestamp      = 0;
     TrackNumber        = 0;
     bLocalTimecodeUsed = false;
     FirstFrameLocation = 0;
@@ -936,7 +936,7 @@ void KaxInternalBlock::SetParent(KaxCluster & aParentCluster)
 {
   ParentCluster = &aParentCluster;
   if (bLocalTimecodeUsed) {
-    Timestamp = aParentCluster.GetBlockGlobalTimecode(LocalTimecode);
+    Timestamp = aParentCluster.GetBlockGlobalTimecode(LocalTimestamp);
     bLocalTimecodeUsed = false;
   }
 }

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -770,8 +770,6 @@ bool KaxBlockGroup::AddFrame(const KaxTrackEntry & track, std::uint64_t timestam
 
 bool KaxBlockGroup::AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, const KaxBlockGroup & PastBlock, LacingType lacing)
 {
-  //  assert(past_timecode < 0);
-
   auto & theBlock = GetChild<KaxBlock>(*this);
   assert(ParentCluster);
   theBlock.SetParent(*ParentCluster);
@@ -787,10 +785,6 @@ bool KaxBlockGroup::AddFrame(const KaxTrackEntry & track, std::uint64_t timestam
 
 bool KaxBlockGroup::AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, const KaxBlockGroup & PastBlock, const KaxBlockGroup & ForwBlock, LacingType lacing)
 {
-  //  assert(past_timecode < 0);
-
-  //  assert(forw_timecode > 0);
-
   auto & theBlock = GetChild<KaxBlock>(*this);
   assert(ParentCluster);
   theBlock.SetParent(*ParentCluster);

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -905,7 +905,7 @@ void KaxBlockGroup::SetBlockDuration(std::uint64_t TimeLength)
   myDuration->SetValue(TimeLength / static_cast<std::uint64_t>(scale));
 }
 
-bool KaxBlockGroup::GetBlockDuration(std::uint64_t &TheTimecode) const
+bool KaxBlockGroup::GetBlockDuration(std::uint64_t &TheTimestamp) const
 {
   const auto myDuration = static_cast<KaxBlockDuration *>(FindElt(EBML_INFO(KaxBlockDuration)));
   if (!myDuration) {
@@ -913,7 +913,7 @@ bool KaxBlockGroup::GetBlockDuration(std::uint64_t &TheTimecode) const
   }
 
   assert(ParentTrack);
-  TheTimecode = static_cast<std::uint64_t>(*myDuration) * ParentTrack->GlobalTimecodeScale();
+  TheTimestamp = static_cast<std::uint64_t>(*myDuration) * ParentTrack->GlobalTimecodeScale();
   return true;
 }
 

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -54,7 +54,7 @@ KaxInternalBlock::~KaxInternalBlock()
 
 KaxInternalBlock::KaxInternalBlock(const KaxInternalBlock & ElementToClone)
   :EbmlBinary(ElementToClone)
-  ,Timecode(ElementToClone.Timecode)
+  ,Timestamp(ElementToClone.Timestamp)
   ,LocalTimecode(ElementToClone.LocalTimecode)
   ,bLocalTimecodeUsed(ElementToClone.bLocalTimecodeUsed)
   ,TrackNumber(ElementToClone.TrackNumber)
@@ -158,7 +158,7 @@ bool KaxInternalBlock::AddFrame(const KaxTrackEntry & track, std::uint64_t times
   SetValueIsSet();
   if (myBuffers.empty()) {
     // first frame
-    Timecode = timestamp;
+    Timestamp = timestamp;
     TrackNumber = static_cast<std::uint64_t>(track.TrackNumber());
     mInvisible = invisible;
     mLacing = lacing;
@@ -261,7 +261,7 @@ filepos_t KaxInternalBlock::UpdateSize(ShouldWrite, bool /* bForceRender */)
 
 KaxBlockVirtual::KaxBlockVirtual(const KaxBlockVirtual & ElementToClone)
   :EbmlBinary(ElementToClone)
-  ,Timecode(ElementToClone.Timecode)
+  ,Timestamp(ElementToClone.Timestamp)
   ,TrackNumber(ElementToClone.TrackNumber)
   ,ParentCluster(ElementToClone.ParentCluster) ///< \todo not exactly
 {
@@ -297,7 +297,7 @@ filepos_t KaxBlockVirtual::UpdateSize(ShouldWrite, bool /* bForceRender */)
   }
 
   assert(ParentCluster);
-  const std::int16_t ActualTimecode = ParentCluster->GetBlockLocalTimecode(Timecode);
+  const std::int16_t ActualTimecode = ParentCluster->GetBlockLocalTimecode(Timestamp);
   endian::to_big16(ActualTimecode, cursor);
   cursor += 2;
 
@@ -340,7 +340,7 @@ filepos_t KaxInternalBlock::RenderData(IOCallback & output, bool /* bForceRender
   }
 
   assert(ParentCluster);
-  const std::int16_t ActualTimecode = ParentCluster->GetBlockLocalTimecode(Timecode);
+  const std::int16_t ActualTimecode = ParentCluster->GetBlockLocalTimecode(Timestamp);
   endian::to_big16(ActualTimecode, cursor);
   cursor += 2;
 
@@ -473,7 +473,7 @@ std::uint64_t KaxInternalBlock::ReadInternalHead(IOCallback & input)
 
   assert(ParentCluster);
   std::int16_t stamp = endian::from_big16(cursor);
-  Timecode = ParentCluster->GetBlockGlobalTimecode(stamp);
+  Timestamp = ParentCluster->GetBlockGlobalTimecode(stamp);
   bLocalTimecodeUsed = false;
   cursor += 2;
 
@@ -747,7 +747,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
 
     myBuffers.clear();
     SizeList.clear();
-    Timecode           = 0;
+    Timestamp          = 0;
     LocalTimecode      = 0;
     TrackNumber        = 0;
     bLocalTimecodeUsed = false;
@@ -942,7 +942,7 @@ void KaxInternalBlock::SetParent(KaxCluster & aParentCluster)
 {
   ParentCluster = &aParentCluster;
   if (bLocalTimecodeUsed) {
-    Timecode = aParentCluster.GetBlockGlobalTimecode(LocalTimecode);
+    Timestamp = aParentCluster.GetBlockGlobalTimecode(LocalTimecode);
     bLocalTimecodeUsed = false;
   }
 }

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -56,7 +56,7 @@ KaxInternalBlock::KaxInternalBlock(const KaxInternalBlock & ElementToClone)
   :EbmlBinary(ElementToClone)
   ,Timestamp(ElementToClone.Timestamp)
   ,LocalTimestamp(ElementToClone.LocalTimestamp)
-  ,bLocalTimecodeUsed(ElementToClone.bLocalTimecodeUsed)
+  ,bLocalTimestampUsed(ElementToClone.bLocalTimestampUsed)
   ,TrackNumber(ElementToClone.TrackNumber)
   ,ParentCluster(ElementToClone.ParentCluster) ///< \todo not exactly
 {
@@ -474,7 +474,7 @@ std::uint64_t KaxInternalBlock::ReadInternalHead(IOCallback & input)
   assert(ParentCluster);
   std::int16_t stamp = endian::from_big16(cursor);
   Timestamp = ParentCluster->GetBlockGlobalTimecode(stamp);
-  bLocalTimecodeUsed = false;
+  bLocalTimestampUsed = false;
   cursor += 2;
 
   return Result;
@@ -518,7 +518,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
       }
 
       LocalTimestamp = static_cast<std::int16_t>(Mem.GetUInt16BE());
-      bLocalTimecodeUsed = true;
+      bLocalTimestampUsed = true;
 
       const std::uint8_t Flags = Mem.GetUInt8();
       if (EbmlId(*this) == EBML_ID(KaxSimpleBlock)) {
@@ -643,7 +643,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
       }
 
       LocalTimestamp = endian::from_big16(cursor);
-      bLocalTimecodeUsed = true;
+      bLocalTimestampUsed = true;
       cursor += 2;
 
       if (EbmlId(*this) == EBML_ID(KaxSimpleBlock)) {
@@ -750,7 +750,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
     Timestamp          = 0;
     LocalTimestamp      = 0;
     TrackNumber        = 0;
-    bLocalTimecodeUsed = false;
+    bLocalTimestampUsed = false;
     FirstFrameLocation = 0;
 
     return 0;
@@ -935,9 +935,9 @@ void KaxSimpleBlock::SetParent(KaxCluster & aParentCluster) {
 void KaxInternalBlock::SetParent(KaxCluster & aParentCluster)
 {
   ParentCluster = &aParentCluster;
-  if (bLocalTimecodeUsed) {
+  if (bLocalTimestampUsed) {
     Timestamp = aParentCluster.GetBlockGlobalTimecode(LocalTimestamp);
-    bLocalTimecodeUsed = false;
+    bLocalTimestampUsed = false;
   }
 }
 

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -308,7 +308,7 @@ filepos_t KaxBlockVirtual::UpdateSize(ShouldWrite, bool /* bForceRender */)
 
 /*!
   \todo more optimisation is possible (render the Block head and don't copy the buffer in memory, care should be taken with the allocation of Data)
-  \todo the actual timecode to write should be retrieved from the Cluster from here
+  \todo the actual timestamp to write should be retrieved from the Cluster from here
 */
 filepos_t KaxInternalBlock::RenderData(IOCallback & output, bool /* bForceRender */, ShouldWrite)
 {
@@ -832,7 +832,7 @@ bool KaxBlockGroup::AddFrame(const KaxTrackEntry & track, std::uint64_t timestam
 }
 
 /*!
-  \todo we may cache the reference to the timecode block
+  \todo we may cache the reference to the timestamp block
 */
 std::uint64_t KaxBlockGroup::GlobalTimecode() const
 {

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -297,8 +297,8 @@ filepos_t KaxBlockVirtual::UpdateSize(ShouldWrite, bool /* bForceRender */)
   }
 
   assert(ParentCluster);
-  const std::int16_t ActualTimecode = ParentCluster->GetBlockLocalTimecode(Timestamp);
-  endian::to_big16(ActualTimecode, cursor);
+  const std::int16_t ActualTimestamp = ParentCluster->GetBlockLocalTimecode(Timestamp);
+  endian::to_big16(ActualTimestamp, cursor);
   cursor += 2;
 
   *cursor++ = 0; // flags
@@ -340,8 +340,8 @@ filepos_t KaxInternalBlock::RenderData(IOCallback & output, bool /* bForceRender
   }
 
   assert(ParentCluster);
-  const std::int16_t ActualTimecode = ParentCluster->GetBlockLocalTimecode(Timestamp);
-  endian::to_big16(ActualTimecode, cursor);
+  const std::int16_t ActualTimestamp = ParentCluster->GetBlockLocalTimecode(Timestamp);
+  endian::to_big16(ActualTimestamp, cursor);
   cursor += 2;
 
   *cursor = 0; // flags

--- a/src/KaxBlockData.cpp
+++ b/src/KaxBlockData.cpp
@@ -26,12 +26,12 @@ const KaxBlockBlob & KaxReferenceBlock::RefBlock() const
 KaxReferenceBlock::KaxReferenceBlock()
   :EbmlSInteger(KaxReferenceBlock::ClassInfos)
 {
-  bTimecodeSet = false;
+  bTimestampSet = false;
 }
 
 KaxReferenceBlock::KaxReferenceBlock(const KaxReferenceBlock & ElementToClone)
   :EbmlSInteger(ElementToClone)
-  ,bTimecodeSet(ElementToClone.bTimecodeSet)
+  ,bTimestampSet(ElementToClone.bTimestampSet)
 {
 }
 
@@ -49,7 +49,7 @@ void KaxReferenceBlock::FreeBlob()
 
 filepos_t KaxReferenceBlock::UpdateSize(ShouldWrite writeFilter, bool bForceRender)
 {
-  if (!bTimecodeSet) {
+  if (!bTimestampSet) {
     assert(RefdBlock);
     assert(ParentBlock);
 

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -214,9 +214,9 @@ std::uint64_t KaxCluster::GlobalTimecode() const
   \brief retrieve the relative
   \todo !!! We need a way to know the TimestampScale
 */
-std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimecode) const
+std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimestamp) const
 {
-  const std::int64_t TimecodeDelay = (static_cast<std::int64_t>(aGlobalTimecode) - static_cast<std::int64_t>(GlobalTimecode())) / static_cast<std::int64_t>(GlobalTimecodeScale());
+  const std::int64_t TimecodeDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimecode())) / static_cast<std::int64_t>(GlobalTimecodeScale());
   assert(TimecodeDelay >= std::int16_t(0x8000) && TimecodeDelay <= std::int16_t(0x7FFF));
   return static_cast<std::int16_t>(TimecodeDelay);
 }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -118,7 +118,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
 {
   filepos_t Result = 0;
 
-  // update the Timecode of the Cluster before writing
+  // update the timestamp of the Cluster before writing
   auto Timecode = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
   Timecode->SetValue(GlobalTimecode() / GlobalTimecodeScale());
 
@@ -197,7 +197,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
 }
 
 /*!
-  \todo automatically choose valid timecode for the Cluster based on the previous cluster timecode (must be incremental)
+  \todo automatically choose valid timestamp for the Cluster based on the previous cluster timestamp (must be incremental)
 */
 std::uint64_t KaxCluster::GlobalTimecode() const
 {
@@ -212,7 +212,7 @@ std::uint64_t KaxCluster::GlobalTimecode() const
 
 /*!
   \brief retrieve the relative
-  \todo !!! We need a way to know the TimecodeScale
+  \todo !!! We need a way to know the TimestampScale
 */
 std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimecode) const
 {

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -46,12 +46,12 @@ bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t tim
 {
   if (!bFirstFrameInside) {
     bFirstFrameInside = true;
-    MinTimecode = MaxTimecode = timestamp;
+    MinTimecode = MaxTimestamp = timestamp;
   } else {
     if (timestamp < MinTimecode)
       MinTimecode = timestamp;
-    if (timestamp > MaxTimecode)
-      MaxTimecode = timestamp;
+    if (timestamp > MaxTimestamp)
+      MaxTimestamp = timestamp;
   }
 
   MyNewBlock = nullptr;
@@ -226,7 +226,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimecode)
   if (!bFirstFrameInside) {
     auto Timecode = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
     assert (bFirstFrameInside); // use the InitTimecode() hack for now
-    MinTimecode = MaxTimecode = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
+    MinTimecode = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
     bFirstFrameInside = true;
     bPreviousTimestampIsSet = true;
   }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -216,9 +216,9 @@ std::uint64_t KaxCluster::GlobalTimecode() const
 */
 std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimestamp) const
 {
-  const std::int64_t TimecodeDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimecode())) / static_cast<std::int64_t>(GlobalTimecodeScale());
-  assert(TimecodeDelay >= std::int16_t(0x8000) && TimecodeDelay <= std::int16_t(0x7FFF));
-  return static_cast<std::int16_t>(TimecodeDelay);
+  const std::int64_t TimestampDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimecode())) / static_cast<std::int64_t>(GlobalTimecodeScale());
+  assert(TimestampDelay >= std::int16_t(0x8000) && TimestampDelay <= std::int16_t(0x7FFF));
+  return static_cast<std::int16_t>(TimestampDelay);
 }
 
 std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimestamp)

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -42,16 +42,16 @@ bool KaxCluster::AddBlockBlob(KaxBlockBlob * NewBlob)
   return true;
 }
 
-bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup * PastBlock, const KaxBlockGroup * ForwBlock, LacingType lacing)
+bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup * PastBlock, const KaxBlockGroup * ForwBlock, LacingType lacing)
 {
   if (!bFirstFrameInside) {
     bFirstFrameInside = true;
-    MinTimecode = MaxTimecode = timecode;
+    MinTimecode = MaxTimecode = timestamp;
   } else {
-    if (timecode < MinTimecode)
-      MinTimecode = timecode;
-    if (timecode > MaxTimecode)
-      MaxTimecode = timecode;
+    if (timestamp < MinTimecode)
+      MinTimecode = timestamp;
+    if (timestamp > MaxTimecode)
+      MaxTimecode = timestamp;
   }
 
   MyNewBlock = nullptr;
@@ -68,7 +68,7 @@ bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t tim
 
   if (PastBlock) {
     if (ForwBlock) {
-      if (currentNewBlock->AddFrame(track, timecode, buffer, *PastBlock, *ForwBlock, lacing)) {
+      if (currentNewBlock->AddFrame(track, timestamp, buffer, *PastBlock, *ForwBlock, lacing)) {
         // more data are allowed in this Block
         return true;
       }
@@ -76,7 +76,7 @@ bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t tim
       currentNewBlock = nullptr;
       return false;
     }
-    if (currentNewBlock->AddFrame(track, timecode, buffer, *PastBlock, lacing)) {
+    if (currentNewBlock->AddFrame(track, timestamp, buffer, *PastBlock, lacing)) {
         // more data are allowed in this Block
         return true;
       }
@@ -84,7 +84,7 @@ bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t tim
     return false;
   }
 
-  if (currentNewBlock->AddFrame(track, timecode, buffer, lacing)) {
+  if (currentNewBlock->AddFrame(track, timestamp, buffer, lacing)) {
     // more data are allowed in this Block
     return true;
   }
@@ -93,22 +93,22 @@ bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t tim
   return false;
 }
 
-bool KaxCluster::AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, LacingType lacing)
+bool KaxCluster::AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, LacingType lacing)
 {
   assert(Blobs.empty()); // mutually exclusive for the moment
-  return AddFrameInternal(track, timecode, buffer, MyNewBlock, nullptr, nullptr, lacing);
+  return AddFrameInternal(track, timestamp, buffer, MyNewBlock, nullptr, nullptr, lacing);
 }
 
-bool KaxCluster::AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, LacingType lacing)
+bool KaxCluster::AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, LacingType lacing)
 {
   assert(Blobs.empty()); // mutually exclusive for the moment
-  return AddFrameInternal(track, timecode, buffer, MyNewBlock, &PastBlock, nullptr, lacing);
+  return AddFrameInternal(track, timestamp, buffer, MyNewBlock, &PastBlock, nullptr, lacing);
 }
 
-bool KaxCluster::AddFrame(const KaxTrackEntry & track, std::uint64_t timecode, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, const KaxBlockGroup & ForwBlock, LacingType lacing)
+bool KaxCluster::AddFrame(const KaxTrackEntry & track, std::uint64_t timestamp, DataBuffer & buffer, KaxBlockGroup * & MyNewBlock, const KaxBlockGroup & PastBlock, const KaxBlockGroup & ForwBlock, LacingType lacing)
 {
   assert(Blobs.empty()); // mutually exclusive for the moment
-  return AddFrameInternal(track, timecode, buffer, MyNewBlock, &PastBlock, &ForwBlock, lacing);
+  return AddFrameInternal(track, timestamp, buffer, MyNewBlock, &PastBlock, &ForwBlock, lacing);
 }
 
 /*!

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -46,10 +46,10 @@ bool KaxCluster::AddFrameInternal(const KaxTrackEntry & track, std::uint64_t tim
 {
   if (!bFirstFrameInside) {
     bFirstFrameInside = true;
-    MinTimecode = MaxTimestamp = timestamp;
+    MinTimestamp = MaxTimestamp = timestamp;
   } else {
-    if (timestamp < MinTimecode)
-      MinTimecode = timestamp;
+    if (timestamp < MinTimestamp)
+      MinTimestamp = timestamp;
     if (timestamp > MaxTimestamp)
       MaxTimestamp = timestamp;
   }
@@ -202,7 +202,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
 std::uint64_t KaxCluster::GlobalTimecode() const
 {
   assert(bPreviousTimestampIsSet);
-  std::uint64_t result = MinTimecode;
+  std::uint64_t result = MinTimestamp;
 
   if (result < PreviousTimestamp)
     result = PreviousTimestamp + 1;
@@ -226,7 +226,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimecode)
   if (!bFirstFrameInside) {
     auto Timecode = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
     assert (bFirstFrameInside); // use the InitTimecode() hack for now
-    MinTimecode = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
+    MinTimestamp = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
     bFirstFrameInside = true;
     bPreviousTimestampIsSet = true;
   }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -204,8 +204,8 @@ std::uint64_t KaxCluster::GlobalTimecode() const
   assert(bPreviousTimecodeIsSet);
   std::uint64_t result = MinTimecode;
 
-  if (result < PreviousTimecode)
-    result = PreviousTimecode + 1;
+  if (result < PreviousTimestamp)
+    result = PreviousTimestamp + 1;
 
   return result;
 }
@@ -226,7 +226,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimecode)
   if (!bFirstFrameInside) {
     auto Timecode = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
     assert (bFirstFrameInside); // use the InitTimecode() hack for now
-    MinTimecode = MaxTimecode = PreviousTimecode = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
+    MinTimecode = MaxTimecode = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
     bFirstFrameInside = true;
     bPreviousTimecodeIsSet = true;
   }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -221,7 +221,7 @@ std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimecode) co
   return static_cast<std::int16_t>(TimecodeDelay);
 }
 
-std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimecode)
+std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimestamp)
 {
   if (!bFirstFrameInside) {
     auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
@@ -230,7 +230,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimecode)
     bFirstFrameInside = true;
     bPreviousTimestampIsSet = true;
   }
-  return static_cast<std::int64_t>(LocalTimecode * GlobalTimecodeScale()) + GlobalTimecode();
+  return static_cast<std::int64_t>(LocalTimestamp * GlobalTimecodeScale()) + GlobalTimecode();
 }
 
 KaxBlockGroup & KaxCluster::GetNewBlock()

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -201,7 +201,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
 */
 std::uint64_t KaxCluster::GlobalTimecode() const
 {
-  assert(bPreviousTimecodeIsSet);
+  assert(bPreviousTimestampIsSet);
   std::uint64_t result = MinTimecode;
 
   if (result < PreviousTimestamp)
@@ -228,7 +228,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimecode)
     assert (bFirstFrameInside); // use the InitTimecode() hack for now
     MinTimecode = MaxTimecode = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
     bFirstFrameInside = true;
-    bPreviousTimecodeIsSet = true;
+    bPreviousTimestampIsSet = true;
   }
   return static_cast<std::int64_t>(LocalTimecode * GlobalTimecodeScale()) + GlobalTimecode();
 }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -119,8 +119,8 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
   filepos_t Result = 0;
 
   // update the timestamp of the Cluster before writing
-  auto Timecode = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
-  Timecode->SetValue(GlobalTimecode() / GlobalTimecodeScale());
+  auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
+  ClusterTimestamp->SetValue(GlobalTimecode() / GlobalTimecodeScale());
 
   if (Blobs.empty()) {
     // old-school direct KaxBlockGroup
@@ -224,9 +224,9 @@ std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimecode) co
 std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimecode)
 {
   if (!bFirstFrameInside) {
-    auto Timecode = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
+    auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
     assert (bFirstFrameInside); // use the InitTimecode() hack for now
-    MinTimestamp = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(Timecode));
+    MinTimestamp = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(ClusterTimestamp));
     bFirstFrameInside = true;
     bPreviousTimestampIsSet = true;
   }

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -88,7 +88,7 @@ void KaxCues::PositionSet(const KaxBlockGroup & BlockRef)
 */
 const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimestamp) const
 {
-  const std::uint64_t TimecodeToLocate = aTimestamp / GlobalTimecodeScale();
+  const std::uint64_t TimestampToLocate = aTimestamp / GlobalTimecodeScale();
   const KaxCuePoint * aPointPrev = nullptr;
   std::uint64_t aPrevTime = 0;
   std::uint64_t aNextTime = 0xFFFFFFFFFFFFLL;
@@ -100,11 +100,11 @@ const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimestamp) const
       auto aTime = static_cast<const KaxCueTime *>(tmp->FindFirstElt(EBML_INFO(KaxCueTime)));
       if (aTime) {
         auto _Time = static_cast<std::uint64_t>(*aTime);
-        if (_Time > aPrevTime && _Time < TimecodeToLocate) {
+        if (_Time > aPrevTime && _Time < TimestampToLocate) {
           aPrevTime = _Time;
           aPointPrev = tmp;
         }
-        if (_Time < aNextTime && _Time > TimecodeToLocate) {
+        if (_Time < aNextTime && _Time > TimestampToLocate) {
           aNextTime= _Time;
         }
       }

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -86,9 +86,9 @@ void KaxCues::PositionSet(const KaxBlockGroup & BlockRef)
 /*!
   \warning Assume that the list has been sorted (Sort())
 */
-const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimecode) const
+const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimestamp) const
 {
-  const std::uint64_t TimecodeToLocate = aTimecode / GlobalTimecodeScale();
+  const std::uint64_t TimecodeToLocate = aTimestamp / GlobalTimecodeScale();
   const KaxCuePoint * aPointPrev = nullptr;
   std::uint64_t aPrevTime = 0;
   std::uint64_t aNextTime = 0xFFFFFFFFFFFFLL;
@@ -114,9 +114,9 @@ const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimecode) const
   return aPointPrev;
 }
 
-std::uint64_t KaxCues::GetTimecodePosition(std::uint64_t aTimecode) const
+std::uint64_t KaxCues::GetTimecodePosition(std::uint64_t aTimestamp) const
 {
-  const auto aPoint = GetTimecodePoint(aTimecode);
+  const auto aPoint = GetTimecodePoint(aTimestamp);
   if (!aPoint)
     return 0;
 

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -159,12 +159,12 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
   return false;
 }
 
-bool KaxCuePoint::Timecode(std::uint64_t & aTimecode, std::uint64_t GlobalTimestampScale) const
+bool KaxCuePoint::Timecode(std::uint64_t & aTimestamp, std::uint64_t GlobalTimestampScale) const
 {
   const auto aTime = static_cast<const KaxCueTime *>(FindFirstElt(EBML_INFO(KaxCueTime)));
   if (!aTime)
     return false;
-  aTimecode = static_cast<std::uint64_t>(*aTime) * GlobalTimestampScale;
+  aTimestamp = static_cast<std::uint64_t>(*aTime) * GlobalTimestampScale;
   return true;
 }
 

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -24,11 +24,11 @@ namespace libmatroska {
   \todo handle codec state checking
   \todo remove duplicate references (reference to 2 frames that each reference the same frame)
 */
-void KaxCuePoint::PositionSet(const KaxBlockGroup & BlockReference, std::uint64_t GlobalTimecodeScale)
+void KaxCuePoint::PositionSet(const KaxBlockGroup & BlockReference, std::uint64_t GlobalTimestampScale)
 {
   // fill me
   auto & NewTime = GetChild<KaxCueTime>(*this);
-  NewTime.SetValue(BlockReference.GlobalTimecode() / GlobalTimecodeScale);
+  NewTime.SetValue(BlockReference.GlobalTimecode() / GlobalTimestampScale);
 
   auto & NewPositions = AddNewChild<KaxCueTrackPositions>(*this);
   auto & TheTrack = GetChild<KaxCueTrack>(NewPositions);
@@ -41,7 +41,7 @@ void KaxCuePoint::PositionSet(const KaxBlockGroup & BlockReference, std::uint64_
   if (BlockReference.ReferenceCount() != 0) {
     for (unsigned int i=0; i<BlockReference.ReferenceCount(); i++) {
       auto & NewRefs = AddNewChild<KaxCueReference>(NewPositions);
-      NewRefs.AddReference(BlockReference.Reference(i).RefBlock(), GlobalTimecodeScale);
+      NewRefs.AddReference(BlockReference.Reference(i).RefBlock(), GlobalTimestampScale);
     }
   }
 
@@ -54,7 +54,7 @@ void KaxCuePoint::PositionSet(const KaxBlockGroup & BlockReference, std::uint64_
   SetValueIsSet();
 }
 
-void KaxCuePoint::PositionSet(const KaxBlockBlob & BlobReference, std::uint64_t GlobalTimecodeScale)
+void KaxCuePoint::PositionSet(const KaxBlockBlob & BlobReference, std::uint64_t GlobalTimestampScale)
 {
   auto &BlockReference = static_cast<KaxInternalBlock&>(BlobReference);
   const KaxBlockGroup *BlockGroupPointer = nullptr;
@@ -63,19 +63,19 @@ void KaxCuePoint::PositionSet(const KaxBlockBlob & BlobReference, std::uint64_t 
     auto &BlockGroup = static_cast<KaxBlockGroup&>(BlobReference);
     BlockGroupPointer = &BlockGroup;
   }
-  PositionSet(BlockReference, BlockGroupPointer, GlobalTimecodeScale);
+  PositionSet(BlockReference, BlockGroupPointer, GlobalTimestampScale);
 }
 
-void KaxCuePoint::PositionSet(const KaxSimpleBlock & BlockReference, std::uint64_t GlobalTimecodeScale)
+void KaxCuePoint::PositionSet(const KaxSimpleBlock & BlockReference, std::uint64_t GlobalTimestampScale)
 {
-  PositionSet(BlockReference, nullptr, GlobalTimecodeScale);
+  PositionSet(BlockReference, nullptr, GlobalTimestampScale);
 }
 
-void KaxCuePoint::PositionSet(const KaxInternalBlock & BlockReference, const KaxBlockGroup *BlockGroup, std::uint64_t GlobalTimecodeScale)
+void KaxCuePoint::PositionSet(const KaxInternalBlock & BlockReference, const KaxBlockGroup *BlockGroup, std::uint64_t GlobalTimestampScale)
 {
   // fill me
   auto & NewTime = GetChild<KaxCueTime>(*this);
-  NewTime.SetValue(BlockReference.GlobalTimecode() / GlobalTimecodeScale);
+  NewTime.SetValue(BlockReference.GlobalTimecode() / GlobalTimestampScale);
 
   auto & NewPositions = AddNewChild<KaxCueTrackPositions>(*this);
   auto & TheTrack = GetChild<KaxCueTrack>(NewPositions);
@@ -90,7 +90,7 @@ void KaxCuePoint::PositionSet(const KaxInternalBlock & BlockReference, const Kax
     unsigned int i;
     for (i=0; i<BlockReference.ReferenceCount(); i++) {
       KaxCueReference & NewRefs = AddNewChild<KaxCueReference>(NewPositions);
-      NewRefs.AddReference(BlockReference.Reference(i).RefBlock(), GlobalTimecodeScale);
+      NewRefs.AddReference(BlockReference.Reference(i).RefBlock(), GlobalTimestampScale);
     }
   }
 #endif // MATROSKA_VERSION
@@ -109,11 +109,11 @@ void KaxCuePoint::PositionSet(const KaxInternalBlock & BlockReference, const Kax
 /*!
   \todo handle codec state checking
 */
-void KaxCueReference::AddReference(const KaxBlockBlob & BlockReference, std::uint64_t GlobalTimecodeScale)
+void KaxCueReference::AddReference(const KaxBlockBlob & BlockReference, std::uint64_t GlobalTimestampScale)
 {
   auto& theBlock = static_cast<KaxInternalBlock&>(BlockReference);
   auto& NewTime = GetChild<KaxCueRefTime>(*this);
-  NewTime.SetValue(theBlock.GlobalTimecode() / GlobalTimecodeScale);
+  NewTime.SetValue(theBlock.GlobalTimecode() / GlobalTimestampScale);
 
   auto & TheClustPos = GetChild<KaxCueRefCluster>(*this);
   TheClustPos.SetValue(theBlock.ClusterPosition());
@@ -159,12 +159,12 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
   return false;
 }
 
-bool KaxCuePoint::Timecode(std::uint64_t & aTimecode, std::uint64_t GlobalTimecodeScale) const
+bool KaxCuePoint::Timecode(std::uint64_t & aTimecode, std::uint64_t GlobalTimestampScale) const
 {
   const auto aTime = static_cast<const KaxCueTime *>(FindFirstElt(EBML_INFO(KaxCueTime)));
   if (!aTime)
     return false;
-  aTimecode = static_cast<std::uint64_t>(*aTime) * GlobalTimecodeScale;
+  aTimecode = static_cast<std::uint64_t>(*aTime) * GlobalTimestampScale;
   return true;
 }
 

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -127,18 +127,18 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
   auto theCmp = static_cast<const KaxCuePoint *>(Cmp);
 
   // compare timestamp
-  auto TimeCodeA = static_cast<const KaxCueTime *>(FindElt(EBML_INFO(KaxCueTime)));
-  if (!TimeCodeA)
+  auto TimestampA = static_cast<const KaxCueTime *>(FindElt(EBML_INFO(KaxCueTime)));
+  if (!TimestampA)
     return false;
 
-  auto TimeCodeB = static_cast<const KaxCueTime *>(theCmp->FindElt(EBML_INFO(KaxCueTime)));
-  if (!TimeCodeB)
+  auto TimestampB = static_cast<const KaxCueTime *>(theCmp->FindElt(EBML_INFO(KaxCueTime)));
+  if (!TimestampB)
     return false;
 
-  if (TimeCodeA->IsSmallerThan(TimeCodeB))
+  if (TimestampA->IsSmallerThan(TimestampB))
     return true;
 
-  if (TimeCodeB->IsSmallerThan(TimeCodeA))
+  if (TimestampB->IsSmallerThan(TimestampA))
     return false;
 
   // compare tracks (timestamp are equal)

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -126,7 +126,7 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
 
   auto theCmp = static_cast<const KaxCuePoint *>(Cmp);
 
-  // compare timecode
+  // compare timestamp
   auto TimeCodeA = static_cast<const KaxCueTime *>(FindElt(EBML_INFO(KaxCueTime)));
   if (!TimeCodeA)
     return false;
@@ -141,7 +141,7 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
   if (TimeCodeB->IsSmallerThan(TimeCodeA))
     return false;
 
-  // compare tracks (timecodes are equal)
+  // compare tracks (timestamp are equal)
   const auto TrackA = static_cast<const KaxCueTrack *>(FindElt(EBML_INFO(KaxCueTrack)));
   if (!TrackA)
     return false;

--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -31,7 +31,7 @@ using namespace std;
 
 unsigned int BIN_FILE_SIZE = 15000;
 unsigned int TXT_FILE_SIZE = 3000;
-const std::uint64_t  TIMECODE_SCALE = 1000000;
+const std::uint64_t  TIMESTAMP_SCALE = 1000000;
 
 const EbmlElement::ShouldWrite bWriteDefaultValues = EbmlElement::WriteSkipDefault;
 
@@ -78,7 +78,7 @@ int main(int /*argc*/, char **/*argv*/)
     // fill the mandatory Info section
     KaxInfo & MyInfos = GetChild<KaxInfo>(FileSegment);
     KaxTimecodeScale & TimeScale = GetChild<KaxTimecodeScale>(MyInfos);
-    TimeScale.SetValue(TIMECODE_SCALE);
+    TimeScale.SetValue(TIMESTAMP_SCALE);
 
     KaxDuration & SegDuration = GetChild<KaxDuration>(MyInfos);
     SegDuration.SetValue(0.0);
@@ -92,7 +92,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     // fill track 1 params
     KaxTrackEntry & MyTrack1 = GetChild<KaxTrackEntry>(MyTracks);
-    MyTrack1.SetGlobalTimecodeScale(TIMECODE_SCALE);
+    MyTrack1.SetGlobalTimecodeScale(TIMESTAMP_SCALE);
 
     KaxTrackNumber & MyTrack1Number = GetChild<KaxTrackNumber>(MyTrack1);
     MyTrack1Number.SetValue(1);
@@ -147,7 +147,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     // fill track 2 params
     KaxTrackEntry & MyTrack2 = GetNextChild<KaxTrackEntry>(MyTracks, MyTrack1);
-    MyTrack2.SetGlobalTimecodeScale(TIMECODE_SCALE);
+    MyTrack2.SetGlobalTimecodeScale(TIMESTAMP_SCALE);
 
     KaxTrackNumber & MyTrack2Number = GetChild<KaxTrackNumber>(MyTrack2);
     MyTrack2Number.SetValue(200);
@@ -182,34 +182,34 @@ int main(int /*argc*/, char **/*argv*/)
     // "manual" filling of a cluster"
     /// \todo whenever a BlockGroup is created, we should memorize it's position
     KaxCues AllCues;
-    AllCues.SetGlobalTimecodeScale(TIMECODE_SCALE);
+    AllCues.SetGlobalTimecodeScale(TIMESTAMP_SCALE);
 
     KaxCluster Clust1;
     Clust1.SetParent(FileSegment); // mandatory to store references in this Cluster
-    Clust1.SetPreviousTimecode(0, TIMECODE_SCALE); // the first timestamp here
+    Clust1.SetPreviousTimecode(0, TIMESTAMP_SCALE); // the first timestamp here
     Clust1.EnableChecksum();
 
     // automatic filling of a Cluster
     // simple frame
     KaxBlockGroup *MyNewBlock, *MyLastBlockTrk1 = NULL, *MyLastBlockTrk2 = NULL, *MyNewBlock2;
     DataBuffer *data7 = new DataBuffer((binary *)"tototototo", countof("tototototo"));
-    Clust1.AddFrame(MyTrack1, 250 * TIMECODE_SCALE, *data7, MyNewBlock, LACING_EBML);
+    Clust1.AddFrame(MyTrack1, 250 * TIMESTAMP_SCALE, *data7, MyNewBlock, LACING_EBML);
     if (MyNewBlock != NULL)
       MyLastBlockTrk1 = MyNewBlock;
     DataBuffer *data0 = new DataBuffer((binary *)"TOTOTOTO", countof("TOTOTOTO"));
-    Clust1.AddFrame(MyTrack1, 260 * TIMECODE_SCALE, *data0, MyNewBlock); // to test EBML lacing
+    Clust1.AddFrame(MyTrack1, 260 * TIMESTAMP_SCALE, *data0, MyNewBlock); // to test EBML lacing
     if (MyNewBlock != NULL)
       MyLastBlockTrk1 = MyNewBlock;
     DataBuffer *data6 = new DataBuffer((binary *)"tototototo", countof("tototototo"));
-    Clust1.AddFrame(MyTrack1, 270 * TIMECODE_SCALE, *data6, MyNewBlock); // to test lacing
+    Clust1.AddFrame(MyTrack1, 270 * TIMESTAMP_SCALE, *data6, MyNewBlock); // to test lacing
     if (MyNewBlock != NULL) {
       MyLastBlockTrk1 = MyNewBlock;
     } else {
-      MyLastBlockTrk1->SetBlockDuration(50 * TIMECODE_SCALE);
+      MyLastBlockTrk1->SetBlockDuration(50 * TIMESTAMP_SCALE);
     }
 
     DataBuffer *data5 = new DataBuffer((binary *)"tototototo", countof("tototototo"));
-    Clust1.AddFrame(MyTrack2, 23 * TIMECODE_SCALE, *data5, MyNewBlock); // to test with another track
+    Clust1.AddFrame(MyTrack2, 23 * TIMESTAMP_SCALE, *data5, MyNewBlock); // to test with another track
 
     // add the "real" block to the cue entries
         KaxBlockBlob *Blob1 = new KaxBlockBlob(BLOCK_BLOB_NO_SIMPLE);
@@ -218,7 +218,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     // frame for Track 2
     DataBuffer *data8 = new DataBuffer((binary *)"tttyyy", countof("tttyyy"));
-    Clust1.AddFrame(MyTrack2, 107 * TIMECODE_SCALE, *data8, MyNewBlock, *MyLastBlockTrk2);
+    Clust1.AddFrame(MyTrack2, 107 * TIMESTAMP_SCALE, *data8, MyNewBlock, *MyLastBlockTrk2);
 
         KaxBlockBlob *Blob2 = new KaxBlockBlob(BLOCK_BLOB_NO_SIMPLE);
         Blob2->SetBlockGroup(*MyNewBlock);
@@ -226,13 +226,13 @@ int main(int /*argc*/, char **/*argv*/)
 
     // frame with a past reference
     DataBuffer *data4 = new DataBuffer((binary *)"tttyyy", countof("tttyyy"));
-    Clust1.AddFrame(MyTrack1, 300 * TIMECODE_SCALE, *data4, MyNewBlock, *MyLastBlockTrk1);
+    Clust1.AddFrame(MyTrack1, 300 * TIMESTAMP_SCALE, *data4, MyNewBlock, *MyLastBlockTrk1);
 
     // frame with a past & future reference
     if (MyNewBlock != NULL) {
       DataBuffer *data3 = new DataBuffer((binary *)"tttyyy", countof("tttyyy"));
-      if (Clust1.AddFrame(MyTrack1, 280 * TIMECODE_SCALE, *data3, MyNewBlock2, *MyLastBlockTrk1, *MyNewBlock)) {
-        MyNewBlock2->SetBlockDuration(20 * TIMECODE_SCALE);
+      if (Clust1.AddFrame(MyTrack1, 280 * TIMESTAMP_SCALE, *data3, MyNewBlock2, *MyLastBlockTrk1, *MyNewBlock)) {
+        MyNewBlock2->SetBlockDuration(20 * TIMESTAMP_SCALE);
         MyLastBlockTrk1 = MyNewBlock2;
       } else {
         printf("Error adding a frame !!!");
@@ -255,11 +255,11 @@ int main(int /*argc*/, char **/*argv*/)
 
     KaxCluster Clust2;
     Clust2.SetParent(FileSegment); // mandatory to store references in this Cluster
-    Clust2.SetPreviousTimecode(300 * TIMECODE_SCALE, TIMECODE_SCALE); // the first timestamp here
+    Clust2.SetPreviousTimecode(300 * TIMESTAMP_SCALE, TIMESTAMP_SCALE); // the first timestamp here
     Clust2.EnableChecksum();
 
     DataBuffer *data2 = new DataBuffer((binary *)"tttyyy", countof("tttyyy"));
-    Clust2.AddFrame(MyTrack1, 350 * TIMECODE_SCALE, *data2, MyNewBlock, *MyLastBlockTrk1);
+    Clust2.AddFrame(MyTrack1, 350 * TIMESTAMP_SCALE, *data2, MyNewBlock, *MyLastBlockTrk1);
 
         KaxBlockBlob *Blob4 = new KaxBlockBlob(BLOCK_BLOB_NO_SIMPLE);
         Blob4->SetBlockGroup(*MyNewBlock);
@@ -284,7 +284,7 @@ int main(int /*argc*/, char **/*argv*/)
     aChapStart.SetValue(0);
 
     KaxChapterTimeEnd & aChapEnd = GetChild<KaxChapterTimeEnd>(aAtom);
-    aChapEnd.SetValue(300 * TIMECODE_SCALE);
+    aChapEnd.SetValue(300 * TIMESTAMP_SCALE);
 
     KaxChapterDisplay & aDisplay = GetChild<KaxChapterDisplay>(aAtom);
     KaxChapterString & aChapString = GetChild<KaxChapterString>(aDisplay);

--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -186,7 +186,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     KaxCluster Clust1;
     Clust1.SetParent(FileSegment); // mandatory to store references in this Cluster
-    Clust1.SetPreviousTimecode(0, TIMECODE_SCALE); // the first timecode here
+    Clust1.SetPreviousTimecode(0, TIMECODE_SCALE); // the first timestamp here
     Clust1.EnableChecksum();
 
     // automatic filling of a Cluster
@@ -255,7 +255,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     KaxCluster Clust2;
     Clust2.SetParent(FileSegment); // mandatory to store references in this Cluster
-    Clust2.SetPreviousTimecode(300 * TIMECODE_SCALE, TIMECODE_SCALE); // the first timecode here
+    Clust2.SetPreviousTimecode(300 * TIMECODE_SCALE, TIMECODE_SCALE); // the first timestamp here
     Clust2.EnableChecksum();
 
     DataBuffer *data2 = new DataBuffer((binary *)"tttyyy", countof("tttyyy"));

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
   KaxSeekHead *MetaSeek;
   KaxChapters *Chapters;
   KaxTags *AllTags;
-  std::uint64_t TimecodeScale = 1000000;
+  std::uint64_t TimestampScale = 1000000;
 
   // find the segment to read
   ElementLevel0 = aStream.FindNextID(EBML_INFO(KaxSegment), 0xFFFFFFFFL);
@@ -152,12 +152,12 @@ int main(int argc, char **argv)
                   case track_audio:
                     printf("Audio");
                     TrackAudio = static_cast<KaxTrackEntry *>(ElementLevel2);
-                    TrackAudio->SetGlobalTimecodeScale(TimecodeScale);
+                    TrackAudio->SetGlobalTimecodeScale(TimestampScale);
                     break;
                   case track_video:
                     printf("Video");
                     TrackVideo = static_cast<KaxTrackEntry *>(ElementLevel2);
-                    TrackVideo->SetGlobalTimecodeScale(TimecodeScale);
+                    TrackVideo->SetGlobalTimecodeScale(TimestampScale);
                     break;
                   default:
                     printf("unknown");
@@ -230,7 +230,7 @@ int main(int argc, char **argv)
               KaxTimecodeScale *TimeScale = static_cast<KaxTimecodeScale*>(ElementLevel2);
               TimeScale->ReadData(aStream.I_O());
               printf("Timecode Scale %d\n", std::uint32_t(*TimeScale));
-              TimecodeScale = std::uint64_t(*TimeScale);
+              TimestampScale = std::uint64_t(*TimeScale);
             } else if (EbmlId(*ElementLevel2) == EBML_ID(KaxDuration)) {
               printf("Segment duration\n");
             } else if (EbmlId(*ElementLevel2) == EBML_ID(KaxDateUTC)) {
@@ -299,7 +299,7 @@ int main(int argc, char **argv)
               KaxClusterTimecode & ClusterTime = *static_cast<KaxClusterTimecode*>(ElementLevel2);
               ClusterTime.ReadData(aStream.I_O());
               ClusterTimecode = std::uint32_t(ClusterTime);
-              SegmentCluster->InitTimecode(ClusterTimecode, TimecodeScale);
+              SegmentCluster->InitTimecode(ClusterTimecode, TimestampScale);
             } else  if (EbmlId(*ElementLevel2) == EBML_ID(KaxBlockGroup)) {
               printf("Block Group found\n");
 #ifdef TEST_BLOCKGROUP_READ
@@ -318,11 +318,11 @@ int main(int argc, char **argv)
               }
               KaxBlockDuration * BlockDuration = static_cast<KaxBlockDuration *>(aBlockGroup.FindElt(EBML_INFO(KaxBlockDuration)));
               if (BlockDuration != NULL) {
-                printf("  Block Duration %d scaled ticks : %ld ns\n", std::uint32_t(*BlockDuration), std::uint32_t(*BlockDuration) * TimecodeScale);
+                printf("  Block Duration %d scaled ticks : %ld ns\n", std::uint32_t(*BlockDuration), std::uint32_t(*BlockDuration) * TimestampScale);
               }
               KaxReferenceBlock * RefTime = static_cast<KaxReferenceBlock *>(aBlockGroup.FindElt(EBML_INFO(KaxReferenceBlock)));
               if (RefTime != NULL) {
-                printf("  Reference frame at scaled (%d) timecode %ld\n", std::int32_t(*RefTime), std::int32_t(std::int64_t(*RefTime) * TimecodeScale));
+                printf("  Reference frame at scaled (%d) timecode %ld\n", std::int32_t(*RefTime), std::int32_t(std::int64_t(*RefTime) * TimestampScale));
               }
 #else // TEST_BLOCKGROUP_READ
               // read the data we care about in matroska
@@ -360,11 +360,11 @@ int main(int argc, char **argv)
                 } else if (EbmlId(*ElementLevel3) == EBML_ID(KaxReferenceBlock)) {
                   KaxReferenceBlock & RefTime = *static_cast<KaxReferenceBlock*>(ElementLevel3);
                   RefTime.ReadData(aStream.I_O());
-                  printf("  Reference frame at scaled (%d) timecode %" PRId32 "\n", std::int32_t(RefTime), std::int32_t(std::int64_t(RefTime) * TimecodeScale));
+                  printf("  Reference frame at scaled (%d) timecode %" PRId32 "\n", std::int32_t(RefTime), std::int32_t(std::int64_t(RefTime) * TimestampScale));
                 } else if (EbmlId(*ElementLevel3) == EBML_ID(KaxBlockDuration)) {
                   KaxBlockDuration & BlockDuration = *static_cast<KaxBlockDuration*>(ElementLevel3);
                   BlockDuration.ReadData(aStream.I_O());
-                  printf("  Block Duration %" PRIu32 " scaled ticks : %" PRIu64 " ns\n", std::uint32_t(BlockDuration), std::uint32_t(BlockDuration) * TimecodeScale);
+                  printf("  Block Duration %" PRIu32 " scaled ticks : %" PRIu64 " ns\n", std::uint32_t(BlockDuration), std::uint32_t(BlockDuration) * TimestampScale);
                 }
                 if (UpperElementLevel > 0) {
                   UpperElementLevel--;
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
         else if (EbmlId(*ElementLevel1) == EBML_ID(KaxCues)) {
           printf("\n- Cue entries found\n");
           CuesEntry = static_cast<KaxCues *>(ElementLevel1);
-          CuesEntry->SetGlobalTimecodeScale(TimecodeScale);
+          CuesEntry->SetGlobalTimecodeScale(TimestampScale);
           // read everything in memory
           CuesEntry->Read(aStream, EBML_CLASS_CONTEXT(KaxCues), UpperElementLevel, ElementLevel2, bAllowDummy); // build the entries in memory
           if (CuesEntry->CheckMandatory()) {
@@ -444,7 +444,7 @@ int main(int argc, char **argv)
               for (Index1 = 0; Index1<CuePoint.ListSize() ;Index1++) {
                 if (EbmlId(*CuePoint[Index1]) == EBML_ID(KaxCueTime)) {
                   KaxCueTime & CueTime = *static_cast<KaxCueTime *>(CuePoint[Index1]);
-                  printf("  Time %" PRIu64 "\n", std::uint64_t(CueTime) * TimecodeScale);
+                  printf("  Time %" PRIu64 "\n", std::uint64_t(CueTime) * TimestampScale);
                 } else if (EbmlId(*(CuePoint[Index1])) == EBML_ID(KaxCueTrackPositions)) {
                   KaxCueTrackPositions & CuePos = *static_cast<KaxCueTrackPositions *>(CuePoint[Index1]);
                   printf("  Positions\n");

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
           printf("\n- Segment Clusters found\n");
           SegmentCluster = static_cast<KaxCluster *>(ElementLevel1);
 //          SegmentCluster->ClearElement();
-          std::uint32_t ClusterTimecode;
+          std::uint32_t ClusterTimestamp;
           EbmlCrc32 *pChecksum = NULL;
           std::uint64_t CrcPositionStart = 0;
 
@@ -298,8 +298,8 @@ int main(int argc, char **argv)
               printf("Cluster timestamp found\n");
               KaxClusterTimecode & ClusterTime = *static_cast<KaxClusterTimecode*>(ElementLevel2);
               ClusterTime.ReadData(aStream.I_O());
-              ClusterTimecode = std::uint32_t(ClusterTime);
-              SegmentCluster->InitTimecode(ClusterTimecode, TimestampScale);
+              ClusterTimestamp = std::uint32_t(ClusterTime);
+              SegmentCluster->InitTimecode(ClusterTimestamp, TimestampScale);
             } else  if (EbmlId(*ElementLevel2) == EBML_ID(KaxBlockGroup)) {
               printf("Block Group found\n");
 #ifdef TEST_BLOCKGROUP_READ

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
               UpperElementLevel = 0;
             }
             if (EbmlId(*ElementLevel2) == EBML_ID(KaxClusterTimecode)) {
-              printf("Cluster timecode found\n");
+              printf("Cluster timestamp found\n");
               KaxClusterTimecode & ClusterTime = *static_cast<KaxClusterTimecode*>(ElementLevel2);
               ClusterTime.ReadData(aStream.I_O());
               ClusterTimecode = std::uint32_t(ClusterTime);
@@ -312,7 +312,7 @@ int main(int argc, char **argv)
               if (DataBlock != NULL) {
 //                DataBlock->ReadData(aStream.I_O());
                 DataBlock->SetParent(*SegmentCluster);
-                printf("   Track # %d / %d frame%s / Timecode %I64d\n",DataBlock->TrackNum(), DataBlock->NumberFrames(), (DataBlock->NumberFrames() > 1)?"s":"", DataBlock->GlobalTimecode());
+                printf("   Track # %d / %d frame%s / Timestamp %I64d\n",DataBlock->TrackNum(), DataBlock->NumberFrames(), (DataBlock->NumberFrames() > 1)?"s":"", DataBlock->GlobalTimecode());
               } else {
                 printf("   A BlockGroup without a Block !!!");
               }
@@ -322,7 +322,7 @@ int main(int argc, char **argv)
               }
               KaxReferenceBlock * RefTime = static_cast<KaxReferenceBlock *>(aBlockGroup.FindElt(EBML_INFO(KaxReferenceBlock)));
               if (RefTime != NULL) {
-                printf("  Reference frame at scaled (%d) timecode %ld\n", std::int32_t(*RefTime), std::int32_t(std::int64_t(*RefTime) * TimestampScale));
+                printf("  Reference frame at scaled (%d) timestamp %ld\n", std::int32_t(*RefTime), std::int32_t(std::int64_t(*RefTime) * TimestampScale));
               }
 #else // TEST_BLOCKGROUP_READ
               // read the data we care about in matroska
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
                   DataBlock.ReadData(aStream.I_O(), SCOPE_ALL_DATA);
 #endif // NO_DISPLAY_DATA
                   DataBlock.SetParent(*SegmentCluster);
-                  printf("   Track # %d / %d frame%s / Timecode %" PRId64 "\n",DataBlock.TrackNum(), DataBlock.NumberFrames(), (DataBlock.NumberFrames() > 1)?"s":"", DataBlock.GlobalTimecode());
+                  printf("   Track # %d / %d frame%s / Timestamp %" PRId64 "\n",DataBlock.TrackNum(), DataBlock.NumberFrames(), (DataBlock.NumberFrames() > 1)?"s":"", DataBlock.GlobalTimecode());
 #ifndef NO_DISPLAY_DATA
                   for (unsigned int i=0; i< DataBlock.NumberFrames(); i++) {
                     printf("   [%s]\n",DataBlock.GetBuffer(i).Buffer()); // STRING ONLY POSSIBLE WITH THIS PARTICULAR EXAMPLE (the binary data is a string)
@@ -360,7 +360,7 @@ int main(int argc, char **argv)
                 } else if (EbmlId(*ElementLevel3) == EBML_ID(KaxReferenceBlock)) {
                   KaxReferenceBlock & RefTime = *static_cast<KaxReferenceBlock*>(ElementLevel3);
                   RefTime.ReadData(aStream.I_O());
-                  printf("  Reference frame at scaled (%d) timecode %" PRId32 "\n", std::int32_t(RefTime), std::int32_t(std::int64_t(RefTime) * TimestampScale));
+                  printf("  Reference frame at scaled (%d) timestamp %" PRId32 "\n", std::int32_t(RefTime), std::int32_t(std::int64_t(RefTime) * TimestampScale));
                 } else if (EbmlId(*ElementLevel3) == EBML_ID(KaxBlockDuration)) {
                   KaxBlockDuration & BlockDuration = *static_cast<KaxBlockDuration*>(ElementLevel3);
                   BlockDuration.ReadData(aStream.I_O());

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
             if (EbmlId(*ElementLevel2) == EBML_ID(KaxTimecodeScale)) {
               KaxTimecodeScale *TimeScale = static_cast<KaxTimecodeScale*>(ElementLevel2);
               TimeScale->ReadData(aStream.I_O());
-              printf("Timecode Scale %d\n", std::uint32_t(*TimeScale));
+              printf("Timestamp Scale %d\n", std::uint32_t(*TimeScale));
               TimestampScale = std::uint64_t(*TimeScale);
             } else if (EbmlId(*ElementLevel2) == EBML_ID(KaxDuration)) {
               printf("Segment duration\n");


### PR DESCRIPTION
This is the first part of fixing #137. Tha API calls are not changed for now but the internal variables are. So sub-classes using internal variables may not compile anymore.