### PR TITLE
rename *Timecode* methods to *Timestamp* methods

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -147,7 +147,7 @@ DECLARE_MKX_MASTER(KaxBlockGroup)
     /*!
       \return the global timestamp of this Block (not just the delta to the Cluster)
     */
-    std::uint64_t GlobalTimecode() const;
+    std::uint64_t GlobalTimestamp() const;
     std::uint64_t GlobalTimestampScale() const {
       assert(ParentTrack);
       return ParentTrack->GlobalTimestampScale();
@@ -191,7 +191,7 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
     /*!
       \todo !!!! This method needs to be changes !
     */
-    std::uint64_t GlobalTimecode() const {return Timestamp;}
+    std::uint64_t GlobalTimestamp() const {return Timestamp;}
 
     /*!
       \note override this function to generate the Data/Size on the fly, unlike the usual binary elements

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -148,9 +148,9 @@ DECLARE_MKX_MASTER(KaxBlockGroup)
       \return the global timestamp of this Block (not just the delta to the Cluster)
     */
     std::uint64_t GlobalTimecode() const;
-    std::uint64_t GlobalTimecodeScale() const {
+    std::uint64_t GlobalTimestampScale() const {
       assert(ParentTrack);
-      return ParentTrack->GlobalTimecodeScale();
+      return ParentTrack->GlobalTimestampScale();
     }
 
     std::uint16_t TrackNumber() const;

--- a/matroska/KaxBlockData.h
+++ b/matroska/KaxBlockData.h
@@ -32,7 +32,7 @@ DECLARE_MKX_SINTEGER_CONS(KaxReferenceBlock)
     void SetReferencedBlock(const KaxBlockBlob * aRefdBlock);
     void SetReferencedBlock(const KaxBlockGroup & aRefdBlock);
     void SetParentBlock(const KaxBlockGroup & aParentBlock) {ParentBlock = &aParentBlock;}
-    void SetReferencedTimecode(std::int64_t refTimestamp) { SetValue(refTimestamp); bTimestampSet = true;};
+    void SetReferencedTimestamp(std::int64_t refTimestamp) { SetValue(refTimestamp); bTimestampSet = true;};
 
   protected:
     const KaxBlockBlob * RefdBlock{nullptr};

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -92,7 +92,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
       TimestampScale = aGlobalTimestampScale;
       bTimestampScaleIsSet = true;
     }
-    std::uint64_t GlobalTimecodeScale() const {
+    std::uint64_t GlobalTimestampScale() const {
       assert(bTimestampScaleIsSet);
       return TimestampScale;
     }

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -68,7 +68,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     void SetParent(const KaxSegment & aParentSegment) {ParentSegment = &aParentSegment;}
 
-    void SetPreviousTimecode(std::uint64_t aPreviousTimestamp, std::int64_t aTimestampScale) {
+    void SetPreviousTimestamp(std::uint64_t aPreviousTimestamp, std::int64_t aTimestampScale) {
       bPreviousTimestampIsSet = true;
       PreviousTimestamp = aPreviousTimestamp;
       SetGlobalTimestampScale(aTimestampScale);

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -84,7 +84,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
       bFirstFrameInside = bPreviousTimestampIsSet = true;
     }
 
-    std::int16_t GetBlockLocalTimecode(std::uint64_t GlobalTimestamp) const;
+    std::int16_t GetBlockLocalTimestamp(std::uint64_t GlobalTimestamp) const;
 
     std::uint64_t GetBlockGlobalTimestamp(std::int16_t LocalTimestamp);
 

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -86,7 +86,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     std::int16_t GetBlockLocalTimecode(std::uint64_t GlobalTimestamp) const;
 
-    std::uint64_t GetBlockGlobalTimecode(std::int16_t LocalTimestamp);
+    std::uint64_t GetBlockGlobalTimestamp(std::int16_t LocalTimestamp);
 
     void SetGlobalTimestampScale(std::uint64_t aGlobalTimestampScale) {
       TimestampScale = aGlobalTimestampScale;

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -78,7 +78,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
       \note dirty hack to get the mandatory data back after reading
       \todo there should be a better way to get mandatory data
     */
-    void InitTimecode(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
+    void InitTimestamp(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
       SetGlobalTimestampScale(aTimestampScale);
       MinTimestamp = MaxTimestamp = PreviousTimestamp = aTimestamp * TimestampScale;
       bFirstFrameInside = bPreviousTimestampIsSet = true;

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -51,7 +51,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     /*!
       \return the global timestamp of this Cluster
     */
-    std::uint64_t GlobalTimecode() const;
+    std::uint64_t GlobalTimestamp() const;
 
     KaxBlockGroup & GetNewBlock();
 
@@ -84,7 +84,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
       bFirstFrameInside = bPreviousTimestampIsSet = true;
     }
 
-    std::int16_t GetBlockLocalTimecode(std::uint64_t GlobalTimecode) const;
+    std::int16_t GetBlockLocalTimecode(std::uint64_t GlobalTimestamp) const;
 
     std::uint64_t GetBlockGlobalTimecode(std::int16_t LocalTimestamp);
 

--- a/matroska/KaxCluster.h
+++ b/matroska/KaxCluster.h
@@ -71,7 +71,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
     void SetPreviousTimecode(std::uint64_t aPreviousTimestamp, std::int64_t aTimestampScale) {
       bPreviousTimestampIsSet = true;
       PreviousTimestamp = aPreviousTimestamp;
-      SetGlobalTimecodeScale(aTimestampScale);
+      SetGlobalTimestampScale(aTimestampScale);
     }
 
     /*!
@@ -79,7 +79,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
       \todo there should be a better way to get mandatory data
     */
     void InitTimecode(std::uint64_t aTimestamp, std::int64_t aTimestampScale) {
-      SetGlobalTimecodeScale(aTimestampScale);
+      SetGlobalTimestampScale(aTimestampScale);
       MinTimestamp = MaxTimestamp = PreviousTimestamp = aTimestamp * TimestampScale;
       bFirstFrameInside = bPreviousTimestampIsSet = true;
     }
@@ -88,7 +88,7 @@ DECLARE_MKX_MASTER_CONS(KaxCluster)
 
     std::uint64_t GetBlockGlobalTimecode(std::int16_t LocalTimestamp);
 
-    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
+    void SetGlobalTimestampScale(std::uint64_t aGlobalTimestampScale) {
       TimestampScale = aGlobalTimestampScale;
       bTimestampScaleIsSet = true;
     }

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -46,7 +46,7 @@ DECLARE_MKX_MASTER(KaxCues)
       mGlobalTimestampScale = aGlobalTimestampScale;
       bGlobalTimestampScaleIsSet = true;
     }
-    std::uint64_t GlobalTimecodeScale() const {
+    std::uint64_t GlobalTimestampScale() const {
       assert(bGlobalTimestampScaleIsSet);
       return mGlobalTimestampScale;
     }

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -39,7 +39,7 @@ DECLARE_MKX_MASTER(KaxCues)
       return EbmlMaster::Render(output, writeFilter);
     }
 
-    std::uint64_t GetTimecodePosition(std::uint64_t aTimestamp) const;
+    std::uint64_t GetTimestampPosition(std::uint64_t aTimestamp) const;
     const KaxCuePoint * GetTimecodePoint(std::uint64_t aTimestamp) const;
 
     void SetGlobalTimestampScale(std::uint64_t aGlobalTimestampScale) {

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -42,7 +42,7 @@ DECLARE_MKX_MASTER(KaxCues)
     std::uint64_t GetTimecodePosition(std::uint64_t aTimestamp) const;
     const KaxCuePoint * GetTimecodePoint(std::uint64_t aTimestamp) const;
 
-    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
+    void SetGlobalTimestampScale(std::uint64_t aGlobalTimestampScale) {
       mGlobalTimestampScale = aGlobalTimestampScale;
       bGlobalTimestampScaleIsSet = true;
     }

--- a/matroska/KaxCues.h
+++ b/matroska/KaxCues.h
@@ -40,7 +40,7 @@ DECLARE_MKX_MASTER(KaxCues)
     }
 
     std::uint64_t GetTimestampPosition(std::uint64_t aTimestamp) const;
-    const KaxCuePoint * GetTimecodePoint(std::uint64_t aTimestamp) const;
+    const KaxCuePoint * GetTimestampPoint(std::uint64_t aTimestamp) const;
 
     void SetGlobalTimestampScale(std::uint64_t aGlobalTimestampScale) {
       mGlobalTimestampScale = aGlobalTimestampScale;

--- a/matroska/KaxCuesData.h
+++ b/matroska/KaxCuesData.h
@@ -31,7 +31,7 @@ DECLARE_MKX_MASTER(KaxCuePoint)
     bool IsSmallerThan(const EbmlElement *Cmp) const override;
 
     const KaxCueTrackPositions * GetSeekPosition() const;
-    bool Timecode(std::uint64_t & aTimestamp, std::uint64_t GlobalTimestampScale) const;
+    bool Timestamp(std::uint64_t & aTimestamp, std::uint64_t GlobalTimestampScale) const;
 };
 
 DECLARE_MKX_MASTER(KaxCueTrackPositions)

--- a/matroska/KaxTracks.h
+++ b/matroska/KaxTracks.h
@@ -34,7 +34,7 @@ DECLARE_MKX_MASTER(KaxTrackEntry)
       mGlobalTimestampScale = aGlobalTimestampScale;
       bGlobalTimestampScaleIsSet = true;
     }
-    std::uint64_t GlobalTimecodeScale() const {
+    std::uint64_t GlobalTimestampScale() const {
       assert(bGlobalTimestampScaleIsSet);
       return mGlobalTimestampScale;
     }

--- a/matroska/KaxTracks.h
+++ b/matroska/KaxTracks.h
@@ -30,7 +30,7 @@ DECLARE_MKX_MASTER(KaxTrackEntry)
       return(!myLacing || (static_cast<std::uint8_t>(*myLacing) != 0));
     }
 
-    void SetGlobalTimecodeScale(std::uint64_t aGlobalTimestampScale) {
+    void SetGlobalTimestampScale(std::uint64_t aGlobalTimestampScale) {
       mGlobalTimestampScale = aGlobalTimestampScale;
       bGlobalTimestampScaleIsSet = true;
     }

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -297,7 +297,7 @@ filepos_t KaxBlockVirtual::UpdateSize(ShouldWrite, bool /* bForceRender */)
   }
 
   assert(ParentCluster);
-  const std::int16_t ActualTimestamp = ParentCluster->GetBlockLocalTimecode(Timestamp);
+  const std::int16_t ActualTimestamp = ParentCluster->GetBlockLocalTimestamp(Timestamp);
   endian::to_big16(ActualTimestamp, cursor);
   cursor += 2;
 
@@ -340,7 +340,7 @@ filepos_t KaxInternalBlock::RenderData(IOCallback & output, bool /* bForceRender
   }
 
   assert(ParentCluster);
-  const std::int16_t ActualTimestamp = ParentCluster->GetBlockLocalTimecode(Timestamp);
+  const std::int16_t ActualTimestamp = ParentCluster->GetBlockLocalTimestamp(Timestamp);
   endian::to_big16(ActualTimestamp, cursor);
   cursor += 2;
 

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -900,7 +900,7 @@ void KaxInternalBlock::ReleaseFrames()
 void KaxBlockGroup::SetBlockDuration(std::uint64_t TimeLength)
 {
   assert(ParentTrack);
-  const std::int64_t scale = ParentTrack->GlobalTimecodeScale();
+  const std::int64_t scale = ParentTrack->GlobalTimestampScale();
   const auto myDuration = static_cast<KaxBlockDuration *>(FindFirstElt(EBML_INFO(KaxBlockDuration), true));
   myDuration->SetValue(TimeLength / static_cast<std::uint64_t>(scale));
 }
@@ -913,7 +913,7 @@ bool KaxBlockGroup::GetBlockDuration(std::uint64_t &TheTimestamp) const
   }
 
   assert(ParentTrack);
-  TheTimestamp = static_cast<std::uint64_t>(*myDuration) * ParentTrack->GlobalTimecodeScale();
+  TheTimestamp = static_cast<std::uint64_t>(*myDuration) * ParentTrack->GlobalTimestampScale();
   return true;
 }
 

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -473,7 +473,7 @@ std::uint64_t KaxInternalBlock::ReadInternalHead(IOCallback & input)
 
   assert(ParentCluster);
   std::int16_t stamp = endian::from_big16(cursor);
-  Timestamp = ParentCluster->GetBlockGlobalTimecode(stamp);
+  Timestamp = ParentCluster->GetBlockGlobalTimestamp(stamp);
   bLocalTimestampUsed = false;
   cursor += 2;
 
@@ -936,7 +936,7 @@ void KaxInternalBlock::SetParent(KaxCluster & aParentCluster)
 {
   ParentCluster = &aParentCluster;
   if (bLocalTimestampUsed) {
-    Timestamp = aParentCluster.GetBlockGlobalTimecode(LocalTimestamp);
+    Timestamp = aParentCluster.GetBlockGlobalTimestamp(LocalTimestamp);
     bLocalTimestampUsed = false;
   }
 }

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -828,11 +828,11 @@ bool KaxBlockGroup::AddFrame(const KaxTrackEntry & track, std::uint64_t timestam
 /*!
   \todo we may cache the reference to the timestamp block
 */
-std::uint64_t KaxBlockGroup::GlobalTimecode() const
+std::uint64_t KaxBlockGroup::GlobalTimestamp() const
 {
   assert(ParentCluster); // impossible otherwise
   auto MyBlock = static_cast<KaxBlock *>(this->FindElt(EBML_INFO(KaxBlock)));
-  return MyBlock->GlobalTimecode();
+  return MyBlock->GlobalTimestamp();
 }
 
 std::uint16_t KaxBlockGroup::TrackNumber() const
@@ -1006,8 +1006,8 @@ bool KaxBlockBlob::AddFrameAuto(const KaxTrackEntry & track, std::uint64_t times
       Block.simpleblock->SetDiscardable(false);
     } else {
       Block.simpleblock->SetKeyframe(false);
-      if ((!ForwBlock || static_cast<KaxInternalBlock &>(*ForwBlock).GlobalTimecode() <= timestamp) &&
-          (!PastBlock || static_cast<KaxInternalBlock &>(*PastBlock).GlobalTimecode() <= timestamp))
+      if ((!ForwBlock || static_cast<KaxInternalBlock &>(*ForwBlock).GlobalTimestamp() <= timestamp) &&
+          (!PastBlock || static_cast<KaxInternalBlock &>(*PastBlock).GlobalTimestamp() <= timestamp))
         Block.simpleblock->SetDiscardable(false);
       else
         Block.simpleblock->SetDiscardable(true);

--- a/src/KaxBlockData.cpp
+++ b/src/KaxBlockData.cpp
@@ -54,7 +54,7 @@ filepos_t KaxReferenceBlock::UpdateSize(ShouldWrite writeFilter, bool bForceRend
     assert(ParentBlock);
 
     auto &block = static_cast<KaxInternalBlock&>(*RefdBlock);
-    SetValue(static_cast<std::int64_t>(block.GlobalTimecode()) - static_cast<std::int64_t>(ParentBlock->GlobalTimecode()) / static_cast<std::int64_t>(ParentBlock->GlobalTimecodeScale()));
+    SetValue(static_cast<std::int64_t>(block.GlobalTimecode()) - static_cast<std::int64_t>(ParentBlock->GlobalTimecode()) / static_cast<std::int64_t>(ParentBlock->GlobalTimestampScale()));
   }
   return EbmlSInteger::UpdateSize(writeFilter, bForceRender);
 }

--- a/src/KaxBlockData.cpp
+++ b/src/KaxBlockData.cpp
@@ -54,7 +54,7 @@ filepos_t KaxReferenceBlock::UpdateSize(ShouldWrite writeFilter, bool bForceRend
     assert(ParentBlock);
 
     auto &block = static_cast<KaxInternalBlock&>(*RefdBlock);
-    SetValue(static_cast<std::int64_t>(block.GlobalTimecode()) - static_cast<std::int64_t>(ParentBlock->GlobalTimecode()) / static_cast<std::int64_t>(ParentBlock->GlobalTimestampScale()));
+    SetValue(static_cast<std::int64_t>(block.GlobalTimestamp()) - static_cast<std::int64_t>(ParentBlock->GlobalTimestamp()) / static_cast<std::int64_t>(ParentBlock->GlobalTimestampScale()));
   }
   return EbmlSInteger::UpdateSize(writeFilter, bForceRender);
 }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -221,7 +221,7 @@ std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimestamp) c
   return static_cast<std::int16_t>(TimestampDelay);
 }
 
-std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimestamp)
+std::uint64_t KaxCluster::GetBlockGlobalTimestamp(std::int16_t LocalTimestamp)
 {
   if (!bFirstFrameInside) {
     auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -214,7 +214,7 @@ std::uint64_t KaxCluster::GlobalTimestamp() const
   \brief retrieve the relative
   \todo !!! We need a way to know the TimestampScale
 */
-std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimestamp) const
+std::int16_t KaxCluster::GetBlockLocalTimestamp(std::uint64_t aGlobalTimestamp) const
 {
   const std::int64_t TimestampDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimestamp())) / static_cast<std::int64_t>(GlobalTimestampScale());
   assert(TimestampDelay >= std::int16_t(0x8000) && TimestampDelay <= std::int16_t(0x7FFF));

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -225,7 +225,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimestamp(std::int16_t LocalTimestamp)
 {
   if (!bFirstFrameInside) {
     auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
-    assert (bFirstFrameInside); // use the InitTimecode() hack for now
+    assert (bFirstFrameInside); // use the InitTimestamp() hack for now
     MinTimestamp = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(ClusterTimestamp));
     bFirstFrameInside = true;
     bPreviousTimestampIsSet = true;

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -120,7 +120,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
 
   // update the timestamp of the Cluster before writing
   auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
-  ClusterTimestamp->SetValue(GlobalTimecode() / GlobalTimecodeScale());
+  ClusterTimestamp->SetValue(GlobalTimecode() / GlobalTimestampScale());
 
   if (Blobs.empty()) {
     // old-school direct KaxBlockGroup
@@ -216,7 +216,7 @@ std::uint64_t KaxCluster::GlobalTimecode() const
 */
 std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimestamp) const
 {
-  const std::int64_t TimestampDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimecode())) / static_cast<std::int64_t>(GlobalTimecodeScale());
+  const std::int64_t TimestampDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimecode())) / static_cast<std::int64_t>(GlobalTimestampScale());
   assert(TimestampDelay >= std::int16_t(0x8000) && TimestampDelay <= std::int16_t(0x7FFF));
   return static_cast<std::int16_t>(TimestampDelay);
 }
@@ -230,7 +230,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimestamp)
     bFirstFrameInside = true;
     bPreviousTimestampIsSet = true;
   }
-  return static_cast<std::int64_t>(LocalTimestamp * GlobalTimecodeScale()) + GlobalTimecode();
+  return static_cast<std::int64_t>(LocalTimestamp * GlobalTimestampScale()) + GlobalTimecode();
 }
 
 KaxBlockGroup & KaxCluster::GetNewBlock()

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -120,7 +120,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
 
   // update the timestamp of the Cluster before writing
   auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
-  ClusterTimestamp->SetValue(GlobalTimecode() / GlobalTimestampScale());
+  ClusterTimestamp->SetValue(GlobalTimestamp() / GlobalTimestampScale());
 
   if (Blobs.empty()) {
     // old-school direct KaxBlockGroup
@@ -199,7 +199,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
 /*!
   \todo automatically choose valid timestamp for the Cluster based on the previous cluster timestamp (must be incremental)
 */
-std::uint64_t KaxCluster::GlobalTimecode() const
+std::uint64_t KaxCluster::GlobalTimestamp() const
 {
   assert(bPreviousTimestampIsSet);
   std::uint64_t result = MinTimestamp;
@@ -216,7 +216,7 @@ std::uint64_t KaxCluster::GlobalTimecode() const
 */
 std::int16_t KaxCluster::GetBlockLocalTimecode(std::uint64_t aGlobalTimestamp) const
 {
-  const std::int64_t TimestampDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimecode())) / static_cast<std::int64_t>(GlobalTimestampScale());
+  const std::int64_t TimestampDelay = (static_cast<std::int64_t>(aGlobalTimestamp) - static_cast<std::int64_t>(GlobalTimestamp())) / static_cast<std::int64_t>(GlobalTimestampScale());
   assert(TimestampDelay >= std::int16_t(0x8000) && TimestampDelay <= std::int16_t(0x7FFF));
   return static_cast<std::int16_t>(TimestampDelay);
 }
@@ -230,7 +230,7 @@ std::uint64_t KaxCluster::GetBlockGlobalTimecode(std::int16_t LocalTimestamp)
     bFirstFrameInside = true;
     bPreviousTimestampIsSet = true;
   }
-  return static_cast<std::int64_t>(LocalTimestamp * GlobalTimestampScale()) + GlobalTimecode();
+  return static_cast<std::int64_t>(LocalTimestamp * GlobalTimestampScale()) + GlobalTimestamp();
 }
 
 KaxBlockGroup & KaxCluster::GetNewBlock()

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -86,7 +86,7 @@ void KaxCues::PositionSet(const KaxBlockGroup & BlockRef)
 /*!
   \warning Assume that the list has been sorted (Sort())
 */
-const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimestamp) const
+const KaxCuePoint * KaxCues::GetTimestampPoint(std::uint64_t aTimestamp) const
 {
   const std::uint64_t TimestampToLocate = aTimestamp / GlobalTimestampScale();
   const KaxCuePoint * aPointPrev = nullptr;
@@ -116,7 +116,7 @@ const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimestamp) const
 
 std::uint64_t KaxCues::GetTimestampPosition(std::uint64_t aTimestamp) const
 {
-  const auto aPoint = GetTimecodePoint(aTimestamp);
+  const auto aPoint = GetTimestampPoint(aTimestamp);
   if (!aPoint)
     return 0;
 

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -61,7 +61,7 @@ void KaxCues::PositionSet(const KaxBlockBlob & BlockReference)
   if (it != pr.end()) {
     // found, now add the element to the entry list
     auto & NewPoint = AddNewChild<KaxCuePoint>(*this);
-    NewPoint.PositionSet(BlockReference, GlobalTimecodeScale());
+    NewPoint.PositionSet(BlockReference, GlobalTimestampScale());
     myTempReferences.erase(it);
   }
 }
@@ -78,7 +78,7 @@ void KaxCues::PositionSet(const KaxBlockGroup & BlockRef)
   if(it != myTempReferences.end()) {
     // found, now add the element to the entry list
     auto & NewPoint = AddNewChild<KaxCuePoint>(*this);
-    NewPoint.PositionSet(**it, GlobalTimecodeScale());
+    NewPoint.PositionSet(**it, GlobalTimestampScale());
     myTempReferences.erase(it);
   }
 }
@@ -88,7 +88,7 @@ void KaxCues::PositionSet(const KaxBlockGroup & BlockRef)
 */
 const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimestamp) const
 {
-  const std::uint64_t TimestampToLocate = aTimestamp / GlobalTimecodeScale();
+  const std::uint64_t TimestampToLocate = aTimestamp / GlobalTimestampScale();
   const KaxCuePoint * aPointPrev = nullptr;
   std::uint64_t aPrevTime = 0;
   std::uint64_t aNextTime = 0xFFFFFFFFFFFFLL;

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -72,7 +72,7 @@ void KaxCues::PositionSet(const KaxBlockGroup & BlockRef)
   auto it = std::find_if(myTempReferences.begin(), myTempReferences.end(),
     [&](const KaxBlockBlob *myTempReference)
       { auto& refTmp = static_cast<KaxInternalBlock &>(*myTempReference);
-        return refTmp.GlobalTimecode() == BlockRef.GlobalTimecode()
+        return refTmp.GlobalTimestamp() == BlockRef.GlobalTimestamp()
             && refTmp.TrackNum() == BlockRef.TrackNumber(); });
 
   if(it != myTempReferences.end()) {

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -114,7 +114,7 @@ const KaxCuePoint * KaxCues::GetTimecodePoint(std::uint64_t aTimestamp) const
   return aPointPrev;
 }
 
-std::uint64_t KaxCues::GetTimecodePosition(std::uint64_t aTimestamp) const
+std::uint64_t KaxCues::GetTimestampPosition(std::uint64_t aTimestamp) const
 {
   const auto aPoint = GetTimecodePoint(aTimestamp);
   if (!aPoint)

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -159,7 +159,7 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
   return false;
 }
 
-bool KaxCuePoint::Timecode(std::uint64_t & aTimestamp, std::uint64_t GlobalTimestampScale) const
+bool KaxCuePoint::Timestamp(std::uint64_t & aTimestamp, std::uint64_t GlobalTimestampScale) const
 {
   const auto aTime = static_cast<const KaxCueTime *>(FindFirstElt(EBML_INFO(KaxCueTime)));
   if (!aTime)

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -28,7 +28,7 @@ void KaxCuePoint::PositionSet(const KaxBlockGroup & BlockReference, std::uint64_
 {
   // fill me
   auto & NewTime = GetChild<KaxCueTime>(*this);
-  NewTime.SetValue(BlockReference.GlobalTimecode() / GlobalTimestampScale);
+  NewTime.SetValue(BlockReference.GlobalTimestamp() / GlobalTimestampScale);
 
   auto & NewPositions = AddNewChild<KaxCueTrackPositions>(*this);
   auto & TheTrack = GetChild<KaxCueTrack>(NewPositions);
@@ -75,7 +75,7 @@ void KaxCuePoint::PositionSet(const KaxInternalBlock & BlockReference, const Kax
 {
   // fill me
   auto & NewTime = GetChild<KaxCueTime>(*this);
-  NewTime.SetValue(BlockReference.GlobalTimecode() / GlobalTimestampScale);
+  NewTime.SetValue(BlockReference.GlobalTimestamp() / GlobalTimestampScale);
 
   auto & NewPositions = AddNewChild<KaxCueTrackPositions>(*this);
   auto & TheTrack = GetChild<KaxCueTrack>(NewPositions);
@@ -113,7 +113,7 @@ void KaxCueReference::AddReference(const KaxBlockBlob & BlockReference, std::uin
 {
   auto& theBlock = static_cast<KaxInternalBlock&>(BlockReference);
   auto& NewTime = GetChild<KaxCueRefTime>(*this);
-  NewTime.SetValue(theBlock.GlobalTimecode() / GlobalTimestampScale);
+  NewTime.SetValue(theBlock.GlobalTimestamp() / GlobalTimestampScale);
 
   auto & TheClustPos = GetChild<KaxCueRefCluster>(*this);
   TheClustPos.SetValue(theBlock.ClusterPosition());

--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -186,7 +186,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     KaxCluster Clust1;
     Clust1.SetParent(FileSegment); // mandatory to store references in this Cluster
-    Clust1.SetPreviousTimecode(0, TIMESTAMP_SCALE); // the first timestamp here
+    Clust1.SetPreviousTimestamp(0, TIMESTAMP_SCALE); // the first timestamp here
     Clust1.EnableChecksum();
 
     // automatic filling of a Cluster
@@ -255,7 +255,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     KaxCluster Clust2;
     Clust2.SetParent(FileSegment); // mandatory to store references in this Cluster
-    Clust2.SetPreviousTimecode(300 * TIMESTAMP_SCALE, TIMESTAMP_SCALE); // the first timestamp here
+    Clust2.SetPreviousTimestamp(300 * TIMESTAMP_SCALE, TIMESTAMP_SCALE); // the first timestamp here
     Clust2.EnableChecksum();
 
     DataBuffer *data2 = new DataBuffer((binary *)"tttyyy", countof("tttyyy"));

--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -92,7 +92,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     // fill track 1 params
     KaxTrackEntry & MyTrack1 = GetChild<KaxTrackEntry>(MyTracks);
-    MyTrack1.SetGlobalTimecodeScale(TIMESTAMP_SCALE);
+    MyTrack1.SetGlobalTimestampScale(TIMESTAMP_SCALE);
 
     KaxTrackNumber & MyTrack1Number = GetChild<KaxTrackNumber>(MyTrack1);
     MyTrack1Number.SetValue(1);
@@ -147,7 +147,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     // fill track 2 params
     KaxTrackEntry & MyTrack2 = GetNextChild<KaxTrackEntry>(MyTracks, MyTrack1);
-    MyTrack2.SetGlobalTimecodeScale(TIMESTAMP_SCALE);
+    MyTrack2.SetGlobalTimestampScale(TIMESTAMP_SCALE);
 
     KaxTrackNumber & MyTrack2Number = GetChild<KaxTrackNumber>(MyTrack2);
     MyTrack2Number.SetValue(200);
@@ -182,7 +182,7 @@ int main(int /*argc*/, char **/*argv*/)
     // "manual" filling of a cluster"
     /// \todo whenever a BlockGroup is created, we should memorize it's position
     KaxCues AllCues;
-    AllCues.SetGlobalTimecodeScale(TIMESTAMP_SCALE);
+    AllCues.SetGlobalTimestampScale(TIMESTAMP_SCALE);
 
     KaxCluster Clust1;
     Clust1.SetParent(FileSegment); // mandatory to store references in this Cluster

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -152,12 +152,12 @@ int main(int argc, char **argv)
                   case track_audio:
                     printf("Audio");
                     TrackAudio = static_cast<KaxTrackEntry *>(ElementLevel2);
-                    TrackAudio->SetGlobalTimecodeScale(TimestampScale);
+                    TrackAudio->SetGlobalTimestampScale(TimestampScale);
                     break;
                   case track_video:
                     printf("Video");
                     TrackVideo = static_cast<KaxTrackEntry *>(ElementLevel2);
-                    TrackVideo->SetGlobalTimecodeScale(TimestampScale);
+                    TrackVideo->SetGlobalTimestampScale(TimestampScale);
                     break;
                   default:
                     printf("unknown");
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
         else if (EbmlId(*ElementLevel1) == EBML_ID(KaxCues)) {
           printf("\n- Cue entries found\n");
           CuesEntry = static_cast<KaxCues *>(ElementLevel1);
-          CuesEntry->SetGlobalTimecodeScale(TimestampScale);
+          CuesEntry->SetGlobalTimestampScale(TimestampScale);
           // read everything in memory
           CuesEntry->Read(aStream, EBML_CLASS_CONTEXT(KaxCues), UpperElementLevel, ElementLevel2, bAllowDummy); // build the entries in memory
           if (CuesEntry->CheckMandatory()) {

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -299,7 +299,7 @@ int main(int argc, char **argv)
               KaxClusterTimecode & ClusterTime = *static_cast<KaxClusterTimecode*>(ElementLevel2);
               ClusterTime.ReadData(aStream.I_O());
               ClusterTimestamp = std::uint32_t(ClusterTime);
-              SegmentCluster->InitTimecode(ClusterTimestamp, TimestampScale);
+              SegmentCluster->InitTimestamp(ClusterTimestamp, TimestampScale);
             } else  if (EbmlId(*ElementLevel2) == EBML_ID(KaxBlockGroup)) {
               printf("Block Group found\n");
 #ifdef TEST_BLOCKGROUP_READ

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -312,7 +312,7 @@ int main(int argc, char **argv)
               if (DataBlock != NULL) {
 //                DataBlock->ReadData(aStream.I_O());
                 DataBlock->SetParent(*SegmentCluster);
-                printf("   Track # %d / %d frame%s / Timestamp %I64d\n",DataBlock->TrackNum(), DataBlock->NumberFrames(), (DataBlock->NumberFrames() > 1)?"s":"", DataBlock->GlobalTimecode());
+                printf("   Track # %d / %d frame%s / Timestamp %I64d\n",DataBlock->TrackNum(), DataBlock->NumberFrames(), (DataBlock->NumberFrames() > 1)?"s":"", DataBlock->GlobalTimestamp());
               } else {
                 printf("   A BlockGroup without a Block !!!");
               }
@@ -344,7 +344,7 @@ int main(int argc, char **argv)
                   DataBlock.ReadData(aStream.I_O(), SCOPE_ALL_DATA);
 #endif // NO_DISPLAY_DATA
                   DataBlock.SetParent(*SegmentCluster);
-                  printf("   Track # %d / %d frame%s / Timestamp %" PRId64 "\n",DataBlock.TrackNum(), DataBlock.NumberFrames(), (DataBlock.NumberFrames() > 1)?"s":"", DataBlock.GlobalTimecode());
+                  printf("   Track # %d / %d frame%s / Timestamp %" PRId64 "\n",DataBlock.TrackNum(), DataBlock.NumberFrames(), (DataBlock.NumberFrames() > 1)?"s":"", DataBlock.GlobalTimestamp());
 #ifndef NO_DISPLAY_DATA
                   for (unsigned int i=0; i< DataBlock.NumberFrames(); i++) {
                     printf("   [%s]\n",DataBlock.GetBuffer(i).Buffer()); // STRING ONLY POSSIBLE WITH THIS PARTICULAR EXAMPLE (the binary data is a string)


### PR DESCRIPTION
This is the second part of #143. The third part will be renaming the classes, which requires splitting the output of the spectools between libmatroska 1.x and 2.x