### PR TITLE
[1.x] limit the seekID size to 4

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -49,7 +49,7 @@ using namespace libebml;
 namespace libmatroska {
 DECLARE_MKX_BINARY (KaxSeekID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() <= 4;}
+  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 4;}
 };
 
 DECLARE_MKX_UINTEGER(KaxSeekPosition)


### PR DESCRIPTION
It's not legal to be any other size as described in https://github.com/ietf-wg-cellar/matroska-specification/pull/731