### PR TITLE
Rename *Timecode* class and debug names to *Timestamp*

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -74,7 +74,7 @@ DECLARE_MKX_UINTEGER(KaxChapterTranslateCodec)
 DECLARE_MKX_UINTEGER(KaxChapterTranslateEditionUID)
 };
 
-DECLARE_MKX_UINTEGER_DEF(KaxTimecodeScale)
+DECLARE_MKX_UINTEGER_DEF(KaxTimestampScale)
 };
 
 DECLARE_MKX_FLOAT(KaxDuration)
@@ -92,7 +92,7 @@ DECLARE_MKX_UNISTRING(KaxMuxingApp)
 DECLARE_MKX_UNISTRING(KaxWritingApp)
 };
 
-DECLARE_MKX_UINTEGER(KaxClusterTimecode)
+DECLARE_MKX_UINTEGER(KaxClusterTimestamp)
 };
 
 DECLARE_MKX_MASTER(KaxClusterSilentTracks)
@@ -185,7 +185,7 @@ public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
 };
 
-DECLARE_MKX_UINTEGER(KaxReferenceTimeCode)
+DECLARE_MKX_UINTEGER(KaxReferenceTimestamp)
 public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
 };
@@ -250,7 +250,7 @@ DECLARE_MKX_UINTEGER(KaxTrackDefaultDuration)
 DECLARE_MKX_UINTEGER(KaxTrackDefaultDecodedFieldDuration)
 };
 
-DECLARE_MKX_FLOAT_DEF(KaxTrackTimecodeScale)
+DECLARE_MKX_FLOAT_DEF(KaxTrackTimestampScale)
 public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
 };

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -119,7 +119,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, ShouldW
   filepos_t Result = 0;
 
   // update the timestamp of the Cluster before writing
-  auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
+  auto ClusterTimestamp = static_cast<KaxClusterTimestamp *>(this->FindElt(EBML_INFO(KaxClusterTimestamp)));
   ClusterTimestamp->SetValue(GlobalTimestamp() / GlobalTimestampScale());
 
   if (Blobs.empty()) {
@@ -224,7 +224,7 @@ std::int16_t KaxCluster::GetBlockLocalTimestamp(std::uint64_t aGlobalTimestamp) 
 std::uint64_t KaxCluster::GetBlockGlobalTimestamp(std::int16_t LocalTimestamp)
 {
   if (!bFirstFrameInside) {
-    auto ClusterTimestamp = static_cast<KaxClusterTimecode *>(this->FindElt(EBML_INFO(KaxClusterTimecode)));
+    auto ClusterTimestamp = static_cast<KaxClusterTimestamp *>(this->FindElt(EBML_INFO(KaxClusterTimestamp)));
     assert (bFirstFrameInside); // use the InitTimestamp() hack for now
     MinTimestamp = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(ClusterTimestamp));
     bFirstFrameInside = true;

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -82,7 +82,7 @@ DEFINE_MKX_MASTER(KaxChapterTranslate, 0x6924, 2, KaxInfo, false, "ChapterTransl
 DEFINE_MKX_BINARY (KaxChapterTranslateID, 0x69A5, 2, KaxChapterTranslate, "ChapterTranslateID")
 DEFINE_MKX_UINTEGER(KaxChapterTranslateCodec, 0x69BF, 2, KaxChapterTranslate, "ChapterTranslateCodec")
 DEFINE_MKX_UINTEGER(KaxChapterTranslateEditionUID, 0x69FC, 2, KaxChapterTranslate, "ChapterTranslateEditionUID")
-DEFINE_MKX_UINTEGER_DEF(KaxTimestampScale, 0x2AD7B1, 3, KaxInfo, "TimecodeScale", 1000000)
+DEFINE_MKX_UINTEGER_DEF(KaxTimestampScale, 0x2AD7B1, 3, KaxInfo, "TimestampScale", 1000000)
 DEFINE_MKX_FLOAT(KaxDuration, 0x4489, 2, KaxInfo, "Duration")
 DEFINE_MKX_DATE    (KaxDateUTC, 0x4461, 2, KaxInfo, "DateUTC")
 DEFINE_MKX_UNISTRING(KaxTitle, 0x7BA9, 2, KaxInfo, "Title")
@@ -100,7 +100,7 @@ DEFINE_SEMANTIC_ITEM(false, false, KaxEncryptedBlock) // not supported
 DEFINE_END_SEMANTIC(KaxCluster)
 
 DEFINE_MKX_MASTER_CONS(KaxCluster, 0x1F43B675, 4, KaxSegment, true, "Cluster")
-DEFINE_MKX_UINTEGER(KaxClusterTimestamp, 0xE7, 1, KaxCluster, "ClusterTimecode")
+DEFINE_MKX_UINTEGER(KaxClusterTimestamp, 0xE7, 1, KaxCluster, "ClusterTimestamp")
 
 DEFINE_START_SEMANTIC(KaxClusterSilentTracks)
 DEFINE_SEMANTIC_ITEM(false, false, KaxClusterSilentTrackNumber) // not supported
@@ -179,7 +179,7 @@ DEFINE_END_SEMANTIC(KaxReferenceFrame)
 
 DEFINE_MKX_MASTER(KaxReferenceFrame, 0xC8, 1, KaxBlockGroup, false, "ReferenceFrame")
 DEFINE_MKX_UINTEGER(KaxReferenceOffset, 0xC9, 1, KaxReferenceFrame, "ReferenceOffset")
-DEFINE_MKX_UINTEGER(KaxReferenceTimestamp, 0xCA, 1, KaxReferenceFrame, "ReferenceTimeCode")
+DEFINE_MKX_UINTEGER(KaxReferenceTimestamp, 0xCA, 1, KaxReferenceFrame, "ReferenceTimestamp")
 DEFINE_MKX_BINARY (KaxEncryptedBlock, 0xAF, 1, KaxCluster, "EncryptedBlock")
 
 DEFINE_START_SEMANTIC(KaxTracks)
@@ -252,7 +252,7 @@ DEFINE_MKX_UINTEGER_DEF(KaxTrackMinCache, 0x6DE7, 2, KaxTrackEntry, "TrackMinCac
 DEFINE_MKX_UINTEGER(KaxTrackMaxCache, 0x6DF8, 2, KaxTrackEntry, "TrackMaxCache")
 DEFINE_MKX_UINTEGER(KaxTrackDefaultDuration, 0x23E383, 3, KaxTrackEntry, "TrackDefaultDuration")
 DEFINE_MKX_UINTEGER(KaxTrackDefaultDecodedFieldDuration, 0x234E7A, 3, KaxTrackEntry, "TrackDefaultDecodedFieldDuration")
-DEFINE_MKX_FLOAT_DEF(KaxTrackTimestampScale, 0x23314F, 3, KaxTrackEntry, "TrackTimecodeScale", 1)
+DEFINE_MKX_FLOAT_DEF(KaxTrackTimestampScale, 0x23314F, 3, KaxTrackEntry, "TrackTimestampScale", 1)
 DEFINE_MKX_SINTEGER_DEF(KaxTrackOffset, 0x537F, 2, KaxTrackEntry, "TrackOffset", 0)
 DEFINE_MKX_UINTEGER_DEF(KaxMaxBlockAdditionID, 0x55EE, 2, KaxTrackEntry, "MaxBlockAdditionID", 0)
 

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -55,7 +55,7 @@ DEFINE_SEMANTIC_ITEM(false, true, KaxNextUID)
 DEFINE_SEMANTIC_ITEM(false, true, KaxNextFilename)
 DEFINE_SEMANTIC_ITEM(false, false, KaxSegmentFamily)
 DEFINE_SEMANTIC_ITEM(false, false, KaxChapterTranslate)
-DEFINE_SEMANTIC_ITEM(true, true, KaxTimecodeScale)
+DEFINE_SEMANTIC_ITEM(true, true, KaxTimestampScale)
 DEFINE_SEMANTIC_ITEM(false, true, KaxDuration)
 DEFINE_SEMANTIC_ITEM(false, true, KaxDateUTC)
 DEFINE_SEMANTIC_ITEM(false, true, KaxTitle)
@@ -82,7 +82,7 @@ DEFINE_MKX_MASTER(KaxChapterTranslate, 0x6924, 2, KaxInfo, false, "ChapterTransl
 DEFINE_MKX_BINARY (KaxChapterTranslateID, 0x69A5, 2, KaxChapterTranslate, "ChapterTranslateID")
 DEFINE_MKX_UINTEGER(KaxChapterTranslateCodec, 0x69BF, 2, KaxChapterTranslate, "ChapterTranslateCodec")
 DEFINE_MKX_UINTEGER(KaxChapterTranslateEditionUID, 0x69FC, 2, KaxChapterTranslate, "ChapterTranslateEditionUID")
-DEFINE_MKX_UINTEGER_DEF(KaxTimecodeScale, 0x2AD7B1, 3, KaxInfo, "TimecodeScale", 1000000)
+DEFINE_MKX_UINTEGER_DEF(KaxTimestampScale, 0x2AD7B1, 3, KaxInfo, "TimecodeScale", 1000000)
 DEFINE_MKX_FLOAT(KaxDuration, 0x4489, 2, KaxInfo, "Duration")
 DEFINE_MKX_DATE    (KaxDateUTC, 0x4461, 2, KaxInfo, "DateUTC")
 DEFINE_MKX_UNISTRING(KaxTitle, 0x7BA9, 2, KaxInfo, "Title")
@@ -90,7 +90,7 @@ DEFINE_MKX_UNISTRING(KaxMuxingApp, 0x4D80, 2, KaxInfo, "MuxingApp")
 DEFINE_MKX_UNISTRING(KaxWritingApp, 0x5741, 2, KaxInfo, "WritingApp")
 
 DEFINE_START_SEMANTIC(KaxCluster)
-DEFINE_SEMANTIC_ITEM(true, true, KaxClusterTimecode)
+DEFINE_SEMANTIC_ITEM(true, true, KaxClusterTimestamp)
 DEFINE_SEMANTIC_ITEM(false, true, KaxClusterSilentTracks) // not supported
 DEFINE_SEMANTIC_ITEM(false, true, KaxClusterPosition)
 DEFINE_SEMANTIC_ITEM(false, true, KaxClusterPrevSize)
@@ -100,7 +100,7 @@ DEFINE_SEMANTIC_ITEM(false, false, KaxEncryptedBlock) // not supported
 DEFINE_END_SEMANTIC(KaxCluster)
 
 DEFINE_MKX_MASTER_CONS(KaxCluster, 0x1F43B675, 4, KaxSegment, true, "Cluster")
-DEFINE_MKX_UINTEGER(KaxClusterTimecode, 0xE7, 1, KaxCluster, "ClusterTimecode")
+DEFINE_MKX_UINTEGER(KaxClusterTimestamp, 0xE7, 1, KaxCluster, "ClusterTimecode")
 
 DEFINE_START_SEMANTIC(KaxClusterSilentTracks)
 DEFINE_SEMANTIC_ITEM(false, false, KaxClusterSilentTrackNumber) // not supported
@@ -174,12 +174,12 @@ DEFINE_MKX_UINTEGER_DEF(KaxSliceDuration, 0xCF, 1, KaxTimeSlice, "SliceDuration"
 
 DEFINE_START_SEMANTIC(KaxReferenceFrame)
 DEFINE_SEMANTIC_ITEM(true, true, KaxReferenceOffset) // DivX specific
-DEFINE_SEMANTIC_ITEM(true, true, KaxReferenceTimeCode) // DivX specific
+DEFINE_SEMANTIC_ITEM(true, true, KaxReferenceTimestamp) // DivX specific
 DEFINE_END_SEMANTIC(KaxReferenceFrame)
 
 DEFINE_MKX_MASTER(KaxReferenceFrame, 0xC8, 1, KaxBlockGroup, false, "ReferenceFrame")
 DEFINE_MKX_UINTEGER(KaxReferenceOffset, 0xC9, 1, KaxReferenceFrame, "ReferenceOffset")
-DEFINE_MKX_UINTEGER(KaxReferenceTimeCode, 0xCA, 1, KaxReferenceFrame, "ReferenceTimeCode")
+DEFINE_MKX_UINTEGER(KaxReferenceTimestamp, 0xCA, 1, KaxReferenceFrame, "ReferenceTimeCode")
 DEFINE_MKX_BINARY (KaxEncryptedBlock, 0xAF, 1, KaxCluster, "EncryptedBlock")
 
 DEFINE_START_SEMANTIC(KaxTracks)
@@ -205,7 +205,7 @@ DEFINE_SEMANTIC_ITEM(true, true, KaxTrackMinCache) // not supported
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackMaxCache) // not supported
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackDefaultDuration)
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackDefaultDecodedFieldDuration)
-DEFINE_SEMANTIC_ITEM(true, true, KaxTrackTimecodeScale)
+DEFINE_SEMANTIC_ITEM(true, true, KaxTrackTimestampScale)
 DEFINE_SEMANTIC_ITEM(false, true, KaxTrackOffset) // not supported
 DEFINE_SEMANTIC_ITEM(true, true, KaxMaxBlockAdditionID)
 DEFINE_SEMANTIC_ITEM(false, false, KaxBlockAdditionMapping)
@@ -252,7 +252,7 @@ DEFINE_MKX_UINTEGER_DEF(KaxTrackMinCache, 0x6DE7, 2, KaxTrackEntry, "TrackMinCac
 DEFINE_MKX_UINTEGER(KaxTrackMaxCache, 0x6DF8, 2, KaxTrackEntry, "TrackMaxCache")
 DEFINE_MKX_UINTEGER(KaxTrackDefaultDuration, 0x23E383, 3, KaxTrackEntry, "TrackDefaultDuration")
 DEFINE_MKX_UINTEGER(KaxTrackDefaultDecodedFieldDuration, 0x234E7A, 3, KaxTrackEntry, "TrackDefaultDecodedFieldDuration")
-DEFINE_MKX_FLOAT_DEF(KaxTrackTimecodeScale, 0x23314F, 3, KaxTrackEntry, "TrackTimecodeScale", 1)
+DEFINE_MKX_FLOAT_DEF(KaxTrackTimestampScale, 0x23314F, 3, KaxTrackEntry, "TrackTimecodeScale", 1)
 DEFINE_MKX_SINTEGER_DEF(KaxTrackOffset, 0x537F, 2, KaxTrackEntry, "TrackOffset", 0)
 DEFINE_MKX_UINTEGER_DEF(KaxMaxBlockAdditionID, 0x55EE, 2, KaxTrackEntry, "MaxBlockAdditionID", 0)
 
@@ -798,7 +798,7 @@ libebml::filepos_t KaxReferenceOffset::RenderData(libebml::IOCallback & /* outpu
   return 0;
 }
 
-libebml::filepos_t KaxReferenceTimeCode::RenderData(libebml::IOCallback & /* output */, bool /* bForceRender */, ShouldWrite /* writeFilter */) {
+libebml::filepos_t KaxReferenceTimestamp::RenderData(libebml::IOCallback & /* output */, bool /* bForceRender */, ShouldWrite /* writeFilter */) {
   assert(false); // no you are not allowed to use this element !
   return 0;
 }
@@ -818,7 +818,7 @@ libebml::filepos_t KaxTrackMaxCache::RenderData(libebml::IOCallback & /* output 
   return 0;
 }
 
-libebml::filepos_t KaxTrackTimecodeScale::RenderData(libebml::IOCallback & /* output */, bool /* bForceRender */, ShouldWrite /* writeFilter */) {
+libebml::filepos_t KaxTrackTimestampScale::RenderData(libebml::IOCallback & /* output */, bool /* bForceRender */, ShouldWrite /* writeFilter */) {
   assert(false); // no you are not allowed to use this element !
   return 0;
 }

--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -77,7 +77,7 @@ int main(int /*argc*/, char **/*argv*/)
 
     // fill the mandatory Info section
     KaxInfo & MyInfos = GetChild<KaxInfo>(FileSegment);
-    KaxTimecodeScale & TimeScale = GetChild<KaxTimecodeScale>(MyInfos);
+    KaxTimestampScale & TimeScale = GetChild<KaxTimestampScale>(MyInfos);
     TimeScale.SetValue(TIMESTAMP_SCALE);
 
     KaxDuration & SegDuration = GetChild<KaxDuration>(MyInfos);

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -226,8 +226,8 @@ int main(int argc, char **argv)
             if (UpperElementLevel < 0) {
               UpperElementLevel = 0;
             }
-            if (EbmlId(*ElementLevel2) == EBML_ID(KaxTimecodeScale)) {
-              KaxTimecodeScale *TimeScale = static_cast<KaxTimecodeScale*>(ElementLevel2);
+            if (EbmlId(*ElementLevel2) == EBML_ID(KaxTimestampScale)) {
+              KaxTimestampScale *TimeScale = static_cast<KaxTimestampScale*>(ElementLevel2);
               TimeScale->ReadData(aStream.I_O());
               printf("Timestamp Scale %d\n", std::uint32_t(*TimeScale));
               TimestampScale = std::uint64_t(*TimeScale);
@@ -294,9 +294,9 @@ int main(int argc, char **argv)
             if (UpperElementLevel < 0) {
               UpperElementLevel = 0;
             }
-            if (EbmlId(*ElementLevel2) == EBML_ID(KaxClusterTimecode)) {
+            if (EbmlId(*ElementLevel2) == EBML_ID(KaxClusterTimestamp)) {
               printf("Cluster timestamp found\n");
-              KaxClusterTimecode & ClusterTime = *static_cast<KaxClusterTimecode*>(ElementLevel2);
+              KaxClusterTimestamp & ClusterTime = *static_cast<KaxClusterTimestamp*>(ElementLevel2);
               ClusterTime.ReadData(aStream.I_O());
               ClusterTimestamp = std::uint32_t(ClusterTime);
               SegmentCluster->InitTimestamp(ClusterTimestamp, TimestampScale);

--- a/test/tags/test9.cpp
+++ b/test/tags/test9.cpp
@@ -48,7 +48,7 @@ int main() {
     head.Render(out);
 
     KaxInfo &info = GetChild<KaxInfo>(segment);
-    KaxTimecodeScale &time_scale = GetChild<KaxTimecodeScale>(info);
+    KaxTimestampScale &time_scale = GetChild<KaxTimestampScale>(info);
     time_scale.SetValue(1000000);
 
     segment.WriteHead(out, 5);


### PR DESCRIPTION
That's the last part to fix #137.

Matches the output of https://github.com/Matroska-Org/foundation-source/pull/136

~~On top of https://github.com/Matroska-Org/libmatroska/pull/153~~