### PR TITLE
Use a macro to set the length constraint on binary elements

### DIFF
--- a/matroska/KaxDefines.h
+++ b/matroska/KaxDefines.h
@@ -55,9 +55,8 @@
     MATROSKA_CLASS_BODY(x)
 
 #define DECLARE_MKX_BINARY_LENGTH(x,len)   \
-    DECLARE_xxx_BINARY(x, MATROSKA_DLL_API) \
+    DECLARE_xxx_BINARY_LENGTH(x, len, MATROSKA_DLL_API) \
     x(const x & ElementToClone) :libebml::EbmlBinary(ElementToClone) {} \
-    bool ValidateSize() const override {return GetSize() == len;} \
     MATROSKA_CLASS_BODY(x)
 
 #define DECLARE_MKX_UNISTRING(x) \

--- a/matroska/KaxDefines.h
+++ b/matroska/KaxDefines.h
@@ -54,6 +54,12 @@
     x(const x & ElementToClone); \
     MATROSKA_CLASS_BODY(x)
 
+#define DECLARE_MKX_BINARY_LENGTH(x,len)   \
+    DECLARE_xxx_BINARY(x, MATROSKA_DLL_API) \
+    x(const x & ElementToClone) :libebml::EbmlBinary(ElementToClone) {} \
+    bool ValidateSize() const override {return GetSize() == len;} \
+    MATROSKA_CLASS_BODY(x)
+
 #define DECLARE_MKX_UNISTRING(x) \
     DECLARE_xxx_UNISTRING(x, MATROSKA_DLL_API) \
     x(const x & ElementToClone) :libebml::EbmlUnicodeString(ElementToClone) {} \

--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -22,9 +22,7 @@
 #include "matroska/KaxDefines.h"
 
 namespace libmatroska {
-DECLARE_MKX_BINARY(KaxSeekID)
-public:
-  bool ValidateSize() const override {return GetSize() == 4;}
+DECLARE_MKX_BINARY_LENGTH(KaxSeekID, 4)
 };
 
 DECLARE_MKX_UINTEGER(KaxSeekPosition)
@@ -33,33 +31,25 @@ DECLARE_MKX_UINTEGER(KaxSeekPosition)
 DECLARE_MKX_MASTER(KaxInfo)
 };
 
-DECLARE_MKX_BINARY(KaxSegmentUID)
-public:
-  bool ValidateSize() const override {return GetSize() == 16;}
+DECLARE_MKX_BINARY_LENGTH(KaxSegmentUID, 16)
 };
 
 DECLARE_MKX_UNISTRING(KaxSegmentFilename)
 };
 
-DECLARE_MKX_BINARY(KaxPrevUID)
-public:
-  bool ValidateSize() const override {return GetSize() == 16;}
+DECLARE_MKX_BINARY_LENGTH(KaxPrevUID, 16)
 };
 
 DECLARE_MKX_UNISTRING(KaxPrevFilename)
 };
 
-DECLARE_MKX_BINARY(KaxNextUID)
-public:
-  bool ValidateSize() const override {return GetSize() == 16;}
+DECLARE_MKX_BINARY_LENGTH(KaxNextUID, 16)
 };
 
 DECLARE_MKX_UNISTRING(KaxNextFilename)
 };
 
-DECLARE_MKX_BINARY(KaxSegmentFamily)
-public:
-  bool ValidateSize() const override {return GetSize() == 16;}
+DECLARE_MKX_BINARY_LENGTH(KaxSegmentFamily, 16)
 };
 
 DECLARE_MKX_MASTER(KaxChapterTranslate)
@@ -394,9 +384,7 @@ public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
 };
 
-DECLARE_MKX_BINARY(KaxVideoColourSpace)
-public:
-  bool ValidateSize() const override {return GetSize() == 4;}
+DECLARE_MKX_BINARY_LENGTH(KaxVideoColourSpace, 4)
 };
 
 DECLARE_MKX_FLOAT(KaxVideoGamma)
@@ -551,10 +539,9 @@ public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
 };
 
-DECLARE_MKX_BINARY(KaxTrickTrackSegmentUID)
+DECLARE_MKX_BINARY_LENGTH(KaxTrickTrackSegmentUID, 16)
 public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
-  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_UINTEGER_DEF(KaxTrickTrackFlag)
@@ -567,10 +554,9 @@ public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
 };
 
-DECLARE_MKX_BINARY(KaxTrickMasterTrackSegmentUID)
+DECLARE_MKX_BINARY_LENGTH(KaxTrickMasterTrackSegmentUID, 16)
 public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
-  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_MASTER(KaxContentEncodings)
@@ -755,9 +741,7 @@ DECLARE_MKX_UINTEGER_DEF(KaxChapterFlagHidden)
 DECLARE_MKX_UINTEGER_DEF(KaxChapterFlagEnabled)
 };
 
-DECLARE_MKX_BINARY(KaxChapterSegmentUID)
-public:
-  bool ValidateSize() const override {return GetSize() == 16;}
+DECLARE_MKX_BINARY_LENGTH(KaxChapterSegmentUID, 16)
 };
 
 DECLARE_MKX_UINTEGER(KaxChapterSkipType)

--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -24,7 +24,7 @@
 namespace libmatroska {
 DECLARE_MKX_BINARY(KaxSeekID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 4;}
+  bool ValidateSize() const override {return GetSize() == 4;}
 };
 
 DECLARE_MKX_UINTEGER(KaxSeekPosition)
@@ -35,7 +35,7 @@ DECLARE_MKX_MASTER(KaxInfo)
 
 DECLARE_MKX_BINARY(KaxSegmentUID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}
+  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_UNISTRING(KaxSegmentFilename)
@@ -43,7 +43,7 @@ DECLARE_MKX_UNISTRING(KaxSegmentFilename)
 
 DECLARE_MKX_BINARY(KaxPrevUID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}
+  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_UNISTRING(KaxPrevFilename)
@@ -51,7 +51,7 @@ DECLARE_MKX_UNISTRING(KaxPrevFilename)
 
 DECLARE_MKX_BINARY(KaxNextUID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}
+  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_UNISTRING(KaxNextFilename)
@@ -59,7 +59,7 @@ DECLARE_MKX_UNISTRING(KaxNextFilename)
 
 DECLARE_MKX_BINARY(KaxSegmentFamily)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}
+  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_MASTER(KaxChapterTranslate)
@@ -396,7 +396,7 @@ public:
 
 DECLARE_MKX_BINARY(KaxVideoColourSpace)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 4;}
+  bool ValidateSize() const override {return GetSize() == 4;}
 };
 
 DECLARE_MKX_FLOAT(KaxVideoGamma)
@@ -554,7 +554,7 @@ public:
 DECLARE_MKX_BINARY(KaxTrickTrackSegmentUID)
 public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}
+  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_UINTEGER_DEF(KaxTrickTrackFlag)
@@ -570,7 +570,7 @@ public:
 DECLARE_MKX_BINARY(KaxTrickMasterTrackSegmentUID)
 public:
   libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter) override;
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}
+  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_MASTER(KaxContentEncodings)
@@ -757,7 +757,7 @@ DECLARE_MKX_UINTEGER_DEF(KaxChapterFlagEnabled)
 
 DECLARE_MKX_BINARY(KaxChapterSegmentUID)
 public:
-  bool ValidateSize() const override {return IsFiniteSize() && GetSize() == 16;}
+  bool ValidateSize() const override {return GetSize() == 16;}
 };
 
 DECLARE_MKX_UINTEGER(KaxChapterSkipType)


### PR DESCRIPTION
The result in the code is the same but it's more readable, less verbose.

Generated with https://github.com/Matroska-Org/foundation-source/pull/137

Requires https://github.com/Matroska-Org/libebml/pull/212