### PR TITLE
remove the MasterContext from EbmlMaster

### DIFF
--- a/src/KaxAttached.cpp
+++ b/src/KaxAttached.cpp
@@ -16,7 +16,7 @@ using namespace libebml;
 namespace libmatroska {
 
 KaxAttached::KaxAttached()
-  :EbmlMaster(KaxAttached::ClassInfos, EBML_CLASS_SEMCONTEXT(KaxAttached))
+  :EbmlMaster(KaxAttached::ClassInfos)
 {
   SetSizeLength(2); // mandatory min size support (for easier updating) (2^(7*2)-2 = 16Ko)
 }

--- a/src/KaxAttachments.cpp
+++ b/src/KaxAttachments.cpp
@@ -15,7 +15,7 @@ using namespace libebml;
 namespace libmatroska {
 
 KaxAttachments::KaxAttachments()
-  :EbmlMaster(KaxAttachments::ClassInfos, EBML_CLASS_SEMCONTEXT(KaxAttachments))
+  :EbmlMaster(KaxAttachments::ClassInfos)
 {
   SetSizeLength(2); // mandatory min size support (for easier updating) (2^(7*2)-2 = 16Ko)
 }

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -68,7 +68,7 @@ KaxInternalBlock::KaxInternalBlock(const KaxInternalBlock & ElementToClone)
 } */
 
 KaxBlockGroup::KaxBlockGroup()
-  :EbmlMaster(KaxBlockGroup::ClassInfos, EBML_CLASS_SEMCONTEXT(KaxBlockGroup))
+  :EbmlMaster(KaxBlockGroup::ClassInfos)
 {}
 
 static constexpr std::int64_t SignedVINT_Shift1 = (1 << ((7*1) - 1)) - 1;

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -17,7 +17,7 @@ using namespace libebml;
 namespace libmatroska {
 
 KaxCluster::KaxCluster()
-  :EbmlMaster(KaxCluster::ClassInfos, EBML_CLASS_SEMCONTEXT(KaxCluster))
+  :EbmlMaster(KaxCluster::ClassInfos)
 {}
 
 KaxCluster::KaxCluster(const KaxCluster & ElementToClone)

--- a/src/KaxSegment.cpp
+++ b/src/KaxSegment.cpp
@@ -21,7 +21,7 @@ using namespace libebml;
 namespace libmatroska {
 
 KaxSegment::KaxSegment()
-  :EbmlMaster(KaxSegment::ClassInfos, EBML_CLASS_SEMCONTEXT(KaxSegment))
+  :EbmlMaster(KaxSegment::ClassInfos)
 {
   SetSizeLength(5); // mandatory min size support (for easier updating) (2^(7*5)-2 = 32Go)
   SetSizeInfinite(); // by default a segment is big and the size is unknown in advance

--- a/src/KaxSemantic.cpp
+++ b/src/KaxSemantic.cpp
@@ -239,7 +239,7 @@ DEFINE_SEMANTIC_ITEM(false, true, KaxTrickMasterTrackSegmentUID)
 DEFINE_SEMANTIC_ITEM(false, true, KaxContentEncodings)
 DEFINE_END_SEMANTIC(KaxTrackEntry)
 
-DEFINE_MKX_MASTER_CONS(KaxTrackEntry, 0xAE, 1, KaxTracks, false, "TrackEntry", VERSION_ALL_MATROSKA)
+DEFINE_MKX_MASTER(KaxTrackEntry, 0xAE, 1, KaxTracks, false, "TrackEntry", VERSION_ALL_MATROSKA)
 DEFINE_MKX_UINTEGER(KaxTrackNumber, 0xD7, 1, KaxTrackEntry, "TrackNumber", VERSION_ALL_MATROSKA)
 DEFINE_MKX_UINTEGER(KaxTrackUID, 0x73C5, 2, KaxTrackEntry, "TrackUID", VERSION_ALL_MATROSKA)
 DEFINE_MKX_UINTEGER(KaxTrackType, 0x83, 1, KaxTrackEntry, "TrackType", VERSION_ALL_MATROSKA)

--- a/src/KaxTracks.cpp
+++ b/src/KaxTracks.cpp
@@ -16,7 +16,7 @@ using namespace libebml;
 namespace libmatroska {
 
 KaxTrackEntry::KaxTrackEntry()
-  :EbmlMaster(KaxTrackEntry::ClassInfos, EBML_CLASS_SEMCONTEXT(KaxTrackEntry))
+  :EbmlMaster(KaxTrackEntry::ClassInfos)
 {}
 
 void KaxTrackEntry::EnableLacing(bool bEnable)

--- a/src/KaxTracks.cpp
+++ b/src/KaxTracks.cpp
@@ -15,10 +15,6 @@ using namespace libebml;
 
 namespace libmatroska {
 
-KaxTrackEntry::KaxTrackEntry()
-  :EbmlMaster(KaxTrackEntry::ClassInfos)
-{}
-
 void KaxTrackEntry::EnableLacing(bool bEnable)
 {
   auto & myLacing = GetChild<KaxTrackFlagLacing>(*this);


### PR DESCRIPTION
It must always be the ClassInfos Context. This the case for all macros. So we don't need to store it a second time.

Requires https://github.com/Matroska-Org/libebml/pull/220