### PR TITLE
add a way to get the actual lacing value used

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -249,6 +249,11 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
      */
     std::int16_t GetRelativeTimestamp() const { return LocalTimestamp; }
 
+    /*!
+     * \return the lacing type read or used for writing
+     */
+    LacingType GetCurrentLacing() const { return mLacing; }
+
   protected:
     std::vector<DataBuffer *> myBuffers;
     std::vector<std::int32_t> SizeList;


### PR DESCRIPTION
When reading we get the actual value. When writing we settle the best value as well.

Not sure if adding this breaks the ABI or not. Otherwise it could be a welcome addition in v1 as well.