### PR TITLE
Move some SimpleBlock flags inside SimpleBlock

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -179,9 +179,8 @@ DECLARE_MKX_MASTER(KaxBlockGroup)
 
 class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
   public:
-    KaxInternalBlock(const libebml::EbmlCallbacks & classInfo, bool bSimple)
-      :libebml::EbmlBinary(classInfo),
-      bIsSimple(bSimple)
+    KaxInternalBlock(const libebml::EbmlCallbacks & classInfo)
+      :libebml::EbmlBinary(classInfo)
     {}
     KaxInternalBlock(const KaxInternalBlock & ElementToClone);
     ~KaxInternalBlock() override;
@@ -261,7 +260,6 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
     std::uint64_t             FirstFrameLocation;
 
     KaxCluster               *ParentCluster{nullptr};
-    bool                      bIsSimple;
 
     libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
 };
@@ -280,7 +278,7 @@ class MATROSKA_DLL_API KaxSimpleBlock : public KaxInternalBlock {
     bool                      bIsKeyframe{true};
     bool                      bIsDiscardable{false};
   public:
-    KaxSimpleBlock() :KaxInternalBlock(KaxSimpleBlock::ClassInfos, true) {}
+    KaxSimpleBlock() :KaxInternalBlock(KaxSimpleBlock::ClassInfos) {}
 
     void SetKeyframe(bool b_keyframe) { bIsKeyframe = b_keyframe; }
     void SetDiscardable(bool b_discard) { bIsDiscardable = b_discard; }

--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -262,8 +262,6 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
 
     KaxCluster               *ParentCluster{nullptr};
     bool                      bIsSimple;
-    bool                      bIsKeyframe{true};
-    bool                      bIsDiscardable{false};
 
     libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, ShouldWrite writeFilter = WriteSkipDefault) override;
 };
@@ -272,13 +270,15 @@ class MATROSKA_DLL_API KaxBlock : public KaxInternalBlock {
   private:
     static const libebml::EbmlCallbacks ClassInfos;
   public:
-    KaxBlock() :KaxInternalBlock(KaxBlock::ClassInfos, false) {}
+    KaxBlock() :KaxInternalBlock(KaxBlock::ClassInfos) {}
     MATROSKA_CLASS_BODY(KaxBlock)
 };
 
 class MATROSKA_DLL_API KaxSimpleBlock : public KaxInternalBlock {
   private:
     static const libebml::EbmlCallbacks ClassInfos;
+    bool                      bIsKeyframe{true};
+    bool                      bIsDiscardable{false};
   public:
     KaxSimpleBlock() :KaxInternalBlock(KaxSimpleBlock::ClassInfos, true) {}
 

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -350,9 +350,10 @@ filepos_t KaxInternalBlock::RenderData(IOCallback & output, bool /* bForceRender
     *cursor = 0x08;
 
   if (bIsSimple) {
-    if (bIsKeyframe)
+    auto *s = reinterpret_cast<const KaxSimpleBlock*>(this);
+    if (s->IsKeyframe())
       *cursor |= 0x80;
-    if (bIsDiscardable)
+    if (s->IsDiscardable())
       *cursor |= 0x01;
   }
 
@@ -517,8 +518,9 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
 
       const std::uint8_t Flags = Mem.GetUInt8();
       if (EbmlId(*this) == EBML_ID(KaxSimpleBlock)) {
-        bIsKeyframe = (Flags & 0x80) != 0;
-        bIsDiscardable = (Flags & 0x01) != 0;
+        auto *s = reinterpret_cast<KaxSimpleBlock*>(this);
+        s->SetKeyframe( (Flags & 0x80) != 0 );
+        s->SetDiscardable( (Flags & 0x01) != 0 );
       }
       mInvisible = (Flags & 0x08) >> 3;
       mLacing = static_cast<LacingType>((Flags & 0x06) >> 1);
@@ -642,8 +644,9 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
       cursor += 2;
 
       if (EbmlId(*this) == EBML_ID(KaxSimpleBlock)) {
-        bIsKeyframe = (*cursor & 0x80) != 0;
-        bIsDiscardable = (*cursor & 0x01) != 0;
+        auto *s = reinterpret_cast<KaxSimpleBlock*>(this);
+        s->SetKeyframe( (*cursor & 0x80) != 0 );
+        s->SetDiscardable( (*cursor & 0x01) != 0 );
       }
       mInvisible = (*cursor & 0x08) >> 3;
       mLacing = static_cast<LacingType>((*cursor++ & 0x06) >> 1);

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -349,7 +349,7 @@ filepos_t KaxInternalBlock::RenderData(IOCallback & output, bool /* bForceRender
   if (mInvisible)
     *cursor = 0x08;
 
-  if (bIsSimple) {
+  if (EbmlId(*this) == EBML_ID(KaxSimpleBlock)) {
     auto *s = reinterpret_cast<const KaxSimpleBlock*>(this);
     if (s->IsKeyframe())
       *cursor |= 0x80;


### PR DESCRIPTION
No need to keep them in the generic class. They don't make sense there.