### PR TITLE
fix test6 includes

### DIFF
--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -7,10 +7,6 @@
     \author Steve Lhomme     <robux4 @ users.sf.net>
 */
 
-#ifdef _MSC_VER
-#include <windows.h>      // for min/max
-#endif // _MSC_VER
-
 #include "matroska/FileKax.h"
 #include "matroska/KaxSegment.h"
 #include "matroska/KaxTracks.h"


### PR DESCRIPTION
We don't need windows.h for that. And it collides with <limits> "max"...