### PR TITLE
CI: bump macOS builds to macos-14

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_libmatroska:
     name: libmatroska ${{ matrix.arch }}
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
macos-latest is not the latest...
https://github.com/actions/runner-images?tab=readme-ov-file#available-images

We should compile with the latest compilers to catch new errors.