### PR TITLE
cmake: remove various warning suppressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,10 @@ endfunction()
 if(DEV_MODE)
   message(STATUS "Using developer mode for ${CMAKE_CXX_COMPILER_ID}")
   set(CMAKE_CXX_EXTENSIONS OFF)
-  add_cxx_flag_if_supported(-Wall -Wno-comment -Wfatal-errors -fstack-protector-strong -Wnon-virtual-dtor -Wextra
-                            -Wunused -Wpedantic -Woverloaded-virtual -Wshadow
-                            -Wno-self-assign -Wno-mismatched-tags -Wno-inconsistent-missing-override
-                            -Wno-potentially-evaluated-expression -Wno-extra-semi -Wno-gnu-zero-variadic-macro-arguments)
-  add_cxx_flag_if_supported(-Qunused-arguments)
+  add_cxx_flag_if_supported(-Wno-error=unused-command-line-argument
+                            -Wall -Wextra -Wpedantic -Wfatal-errors -fstack-protector-strong
+                            -Wno-self-assign
+                            -Wcast-align)
 endif()
 
 set(libmatroska_SOURCES


### PR DESCRIPTION
They are included in -Wall in GCC and Clang. We disable less warnigns now.

Co-authored-by: Rosen Penev

Similar to https://github.com/Matroska-Org/libebml/pull/248