### PR TITLE
Rely less on EbmlElement::HeadSize()

### DIFF
--- a/src/KaxSegment.cpp
+++ b/src/KaxSegment.cpp
@@ -39,7 +39,7 @@ KaxSegment::KaxSegment(const KaxSegment & ElementToClone)
 
 std::uint64_t KaxSegment::GetRelativePosition(std::uint64_t aGlobalPosition) const
 {
-  return aGlobalPosition - GetElementPosition() - HeadSize();
+  return aGlobalPosition - GetDataStart();
 }
 
 std::uint64_t KaxSegment::GetRelativePosition(const EbmlElement & Elt) const
@@ -49,7 +49,7 @@ std::uint64_t KaxSegment::GetRelativePosition(const EbmlElement & Elt) const
 
 std::uint64_t KaxSegment::GetGlobalPosition(std::uint64_t aRelativePosition) const
 {
-  return aRelativePosition + GetElementPosition() + HeadSize();
+  return aRelativePosition + GetDataStart();
 }
 
 } // namespace libmatroska

--- a/test/mux/test6.cpp
+++ b/test/mux/test6.cpp
@@ -59,7 +59,7 @@ int main(int /*argc*/, char **/*argv*/)
     KaxSegment FileSegment;
 
     // size is unknown and will always be, we can render it right away
-    std::uint64_t SegmentSize = FileSegment.WriteHead(out_file, 5, bWriteDefaultValues);
+    FileSegment.WriteHead(out_file, 5, bWriteDefaultValues);
 
     KaxTracks & MyTracks = GetChild<KaxTracks>(FileSegment);
 
@@ -335,8 +335,7 @@ int main(int /*argc*/, char **/*argv*/)
 #endif // VOID_TEST
 
     // let's assume we know the size of the Segment element
-    // the size of the FileSegment is also computed because mandatory elements we don't write ourself exist
-    if (FileSegment.ForceSize(SegmentSize - FileSegment.HeadSize() + MetaSeekSize
+    if (FileSegment.ForceSize(MetaSeekSize
                             + TrackSize + ClusterSize + CueSize + InfoSize + TagsSize + ChapterSize)) {
       FileSegment.OverwriteHead(out_file);
     }


### PR DESCRIPTION
It's also more readable that way. The KaxSegment methods could become inline for better optimizations.