### PR TITLE
do not export Context_xxx of master elements

### DIFF
--- a/matroska/KaxContexts.h
+++ b/matroska/KaxContexts.h
@@ -8,25 +8,12 @@
 #ifndef LIBMATROSKA_CONTEXTS_H
 #define LIBMATROSKA_CONTEXTS_H
 
-#include "matroska/KaxTypes.h"
+#include "matroska/KaxConfig.h"
 #include <ebml/EbmlElement.h>
 
 namespace libmatroska {
 
 extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxMatroska;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxSegment;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxAttachments;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxAttached;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxChapters;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxCluster;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxTags;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxTag;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxBlockGroup;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxCues;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxInfo;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxSeekHead;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxTracks;
-extern const libebml::EbmlSemanticContext MATROSKA_DLL_API Context_KaxTrackEntry;
 
 extern MATROSKA_DLL_API const libebml::EbmlSemanticContext & GetKaxGlobal_Context();
 

--- a/test/ebml/test00.cpp
+++ b/test/ebml/test00.cpp
@@ -126,7 +126,7 @@ int main(void)
     }
     printf("\n");
 
-    ElementLevel0->SkipData(aStream, EBML_CLASS_SEMCONTEXT(EbmlHead));
+    ElementLevel0->SkipData(aStream, EBML_CLASS_CONTEXT(EbmlHead));
     if (ElementLevel0 != NULL)
       delete ElementLevel0;
   }
@@ -144,23 +144,23 @@ int main(void)
 
     int bUpperElement = 0;
 
-    ElementLevel1 = aStream.FindNextElement(EBML_CLASS_SEMCONTEXT(KaxSegment), bUpperElement, 0xFFFFFFFFL, true);
+    ElementLevel1 = aStream.FindNextElement(EBML_CLASS_CONTEXT(KaxSegment), bUpperElement, 0xFFFFFFFFL, true);
 
     while (ElementLevel1 != NULL) {
       /// \todo switch the type of the element to check if it's one we want to handle, like attachements
       if (EbmlId(*ElementLevel1) == EBML_ID(KaxAttachments)) {
         printf("Attachments detected\n");
 
-        ElementLevel2 = aStream.FindNextElement(EBML_CLASS_SEMCONTEXT(KaxAttachments), bUpperElement, 0xFFFFFFFFL, true);
+        ElementLevel2 = aStream.FindNextElement(EBML_CLASS_CONTEXT(KaxAttachments), bUpperElement, 0xFFFFFFFFL, true);
         while (ElementLevel2 != NULL) {
           /// \todo switch the type of the element to check if it's one we want to handle, like attachements
           if (EbmlId(*ElementLevel2) == EBML_ID(KaxAttached)) {
             printf("Attached file detected\n");
           }
 #ifdef SKIP_ATTACHED
-          ElementLevel2 = ElementLevel2->SkipData(aStream, EBML_CLASS_SEMCONTEXT(KaxAttached));
+          ElementLevel2 = ElementLevel2->SkipData(aStream, EBML_CLASS_CONTEXT(KaxAttached));
           if (ElementLevel2 == NULL) {
-            ElementLevel2 = aStream.FindNextID(EBML_CLASS_SEMCONTEXT(KaxAttachments), bUpperElement, 0xFFFFFFFFL, true);
+            ElementLevel2 = aStream.FindNextID(EBML_CLASS_CONTEXT(KaxAttachments), bUpperElement, 0xFFFFFFFFL, true);
 
             if (bUpperElement) {
               printf("Upper level1 element found\n");
@@ -171,7 +171,7 @@ int main(void)
           }
 #else // SKIP_ATTACHED
           // Display the filename (if it exists)
-          ElementLevel3 = aStream.FindNextElement(EBML_CLASS_SEMCONTEXT(KaxAttached), bUpperElement, 0xFFFFFFFFL, false);
+          ElementLevel3 = aStream.FindNextElement(EBML_CLASS_CONTEXT(KaxAttached), bUpperElement, 0xFFFFFFFFL, false);
           while (ElementLevel3 != NULL) {
             /// \todo switch the type of the element to check if it's one we want to handle, like attachements
             if (EbmlId(*ElementLevel3) == EBML_ID(KaxFileName)) {
@@ -179,10 +179,10 @@ int main(void)
               tmp.ReadData(aStream.I_O());
               printf("File Name = %s\n", UTFstring(tmp).GetUTF8().c_str());
             } else {
-              ElementLevel3->SkipData(aStream, EBML_CLASS_SEMCONTEXT(KaxAttached));
+              ElementLevel3->SkipData(aStream, EBML_CLASS_CONTEXT(KaxAttached));
             }
             delete ElementLevel3;
-            ElementLevel3 = aStream.FindNextElement(EBML_CLASS_SEMCONTEXT(KaxAttached), bUpperElement, 0xFFFFFFFFL, false);
+            ElementLevel3 = aStream.FindNextElement(EBML_CLASS_CONTEXT(KaxAttached), bUpperElement, 0xFFFFFFFFL, false);
             if (bUpperElement)
               break;
           }
@@ -191,25 +191,25 @@ int main(void)
             delete ElementLevel2;
             ElementLevel2 = ElementLevel3;
           } else {
-            ElementLevel2->SkipData(aStream, EBML_CLASS_SEMCONTEXT(KaxAttached));
+            ElementLevel2->SkipData(aStream, EBML_CLASS_CONTEXT(KaxAttached));
             delete ElementLevel2;
 
-            ElementLevel2 = aStream.FindNextElement(EBML_CLASS_SEMCONTEXT(KaxAttachments), bUpperElement, 0xFFFFFFFFL, true);
+            ElementLevel2 = aStream.FindNextElement(EBML_CLASS_CONTEXT(KaxAttachments), bUpperElement, 0xFFFFFFFFL, true);
           }
 #endif // SKIP_ATTACHED
         }
       }
-      ElementLevel1->SkipData(aStream, EBML_CLASS_SEMCONTEXT(KaxAttachments));
+      ElementLevel1->SkipData(aStream, EBML_CLASS_CONTEXT(KaxAttachments));
       delete ElementLevel1;
 
-      ElementLevel1 = aStream.FindNextElement(EBML_CLASS_SEMCONTEXT(KaxSegment), bUpperElement, 0xFFFFFFFFL, true);
+      ElementLevel1 = aStream.FindNextElement(EBML_CLASS_CONTEXT(KaxSegment), bUpperElement, 0xFFFFFFFFL, true);
     }
 
-    ElementLevel0->SkipData(aStream, EBML_CLASS_SEMCONTEXT(KaxSegment));
+    ElementLevel0->SkipData(aStream, EBML_CLASS_CONTEXT(KaxSegment));
     if (ElementLevel0 != NULL)
       delete ElementLevel0;
 
-    ElementLevel0 = aStream.FindNextElement(EBML_CLASS_SEMCONTEXT(KaxSegment), bUpperElement, 0xFFFFFFFFL, true);
+    ElementLevel0 = aStream.FindNextElement(EBML_CLASS_CONTEXT(KaxSegment), bUpperElement, 0xFFFFFFFFL, true);
   }
 
   Ebml_Wfile.close();

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
     }
     printf("\n");
 
-    ElementLevel0->SkipData(aStream, EBML_CLASS_SEMCONTEXT(EbmlHead));
+    ElementLevel0->SkipData(aStream, EBML_CLASS_CONTEXT(EbmlHead));
     if (ElementLevel0 != NULL)
       delete ElementLevel0;
   }


### PR DESCRIPTION
It can be retrieved with EBML_CLASS_CONTEXT(), no need to specifically export them from DLLs.
Neither mkvtoolnix nor VLC use these, apart from Context_KaxMatroska,
which doesn't have a definition outside of here.

More radical approach than #183