### PR TITLE
use standard declaration macros for KaxBlock/KaxSimpleBlock

### DIFF
--- a/matroska/KaxBlock.h
+++ b/matroska/KaxBlock.h
@@ -269,22 +269,15 @@ class MATROSKA_DLL_API KaxInternalBlock : public libebml::EbmlBinary {
     libebml::filepos_t RenderData(libebml::IOCallback & output, bool bForceRender, const ShouldWrite & writeFilter = WriteSkipDefault) override;
 };
 
-class MATROSKA_DLL_API KaxBlock : public KaxInternalBlock {
-  private:
-    static const libebml::EbmlCallbacks ClassInfos;
-  public:
-    KaxBlock() :KaxInternalBlock(KaxBlock::ClassInfos) {}
+DECLARE_xxx_BASE(KaxBlock, MATROSKA_DLL_API, KaxInternalBlock)
     MATROSKA_CLASS_BODY(KaxBlock)
 };
 
-class MATROSKA_DLL_API KaxSimpleBlock : public KaxInternalBlock {
+DECLARE_xxx_BASE(KaxSimpleBlock, MATROSKA_DLL_API, KaxInternalBlock)
   private:
-    static const libebml::EbmlCallbacks ClassInfos;
     bool                      bIsKeyframe{true};
     bool                      bIsDiscardable{false};
   public:
-    KaxSimpleBlock() :KaxInternalBlock(KaxSimpleBlock::ClassInfos) {}
-
     void SetKeyframe(bool b_keyframe) { bIsKeyframe = b_keyframe; }
     void SetDiscardable(bool b_discard) { bIsDiscardable = b_discard; }
 

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -63,6 +63,10 @@ KaxInternalBlock::KaxInternalBlock(const KaxInternalBlock & ElementToClone)
 }
 
 
+KaxBlock::KaxBlock() :KaxInternalBlock(KaxBlock::ClassInfos) {}
+KaxSimpleBlock::KaxSimpleBlock() :KaxInternalBlock(KaxSimpleBlock::ClassInfos) {}
+
+
 /* KaxBlockGroup::~KaxBlockGroup()
 {
   //NOTE("KaxBlockGroup::~KaxBlockGroup");


### PR DESCRIPTION
So they can benefit of all the internal changes.