### PR TITLE
Revert "Use typed children macros instead of local casts"

### DIFF
--- a/matroska/KaxTracks.h
+++ b/matroska/KaxTracks.h
@@ -18,7 +18,7 @@ namespace libmatroska {
 
 DECLARE_MKX_MASTER(KaxTrackEntry)
   public:
-    libebml::EbmlUInteger & TrackNumber() const { return *(static_cast<libebml::EbmlUInteger *>(FindFirstElt(EBML_INFO(KaxTrackNumber)))); }
+    libebml::EbmlUInteger & TrackNumber() const { return *(static_cast<libebml::EbmlUInteger *>(FindElt(EBML_INFO(KaxTrackNumber)))); }
 
     void EnableLacing(bool bEnable = true);
 

--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -830,13 +830,13 @@ bool KaxBlockGroup::AddFrame(const KaxTrackEntry & track, std::uint64_t timestam
 std::uint64_t KaxBlockGroup::GlobalTimestamp() const
 {
   assert(ParentCluster); // impossible otherwise
-  auto MyBlock = FindChild<KaxBlock>(*this);
+  auto MyBlock = static_cast<KaxBlock *>(this->FindElt(EBML_INFO(KaxBlock)));
   return MyBlock->GlobalTimestamp();
 }
 
 std::uint16_t KaxBlockGroup::TrackNumber() const
 {
-  auto MyBlock = FindChild<KaxBlock>(*this);
+  auto MyBlock = static_cast<KaxBlock *>(this->FindElt(EBML_INFO(KaxBlock)));
   return MyBlock->TrackNum();
 }
 
@@ -855,10 +855,10 @@ std::uint64_t KaxInternalBlock::ClusterPosition() const
 unsigned int KaxBlockGroup::ReferenceCount() const
 {
   unsigned int Result = 0;
-  auto MyBlockAdds = FindChild<KaxReferenceBlock>(*this);
+  auto MyBlockAdds = static_cast<KaxReferenceBlock *>(FindFirstElt(EBML_INFO(KaxReferenceBlock)));
   if (MyBlockAdds) {
     Result++;
-    while ((MyBlockAdds = FindNextChild<KaxReferenceBlock>(*this, *MyBlockAdds))) {
+    while ((MyBlockAdds = static_cast<KaxReferenceBlock *>(FindNextElt(*MyBlockAdds)))) {
       Result++;
     }
   }
@@ -867,11 +867,11 @@ unsigned int KaxBlockGroup::ReferenceCount() const
 
 const KaxReferenceBlock & KaxBlockGroup::Reference(unsigned int Index) const
 {
-  auto MyBlockAdds = FindChild<KaxReferenceBlock>(*this);
+  auto MyBlockAdds = static_cast<KaxReferenceBlock *>(FindFirstElt(EBML_INFO(KaxReferenceBlock)));
   assert(MyBlockAdds); // call of a non existing reference
 
   while (Index != 0) {
-    MyBlockAdds = FindNextChild<KaxReferenceBlock>(*this, *MyBlockAdds);
+    MyBlockAdds = static_cast<KaxReferenceBlock *>(FindNextElt(*MyBlockAdds));
     assert(MyBlockAdds);
     Index--;
   }
@@ -880,7 +880,7 @@ const KaxReferenceBlock & KaxBlockGroup::Reference(unsigned int Index) const
 
 void KaxBlockGroup::ReleaseFrames()
 {
-  auto MyBlock = FindChild<KaxBlock>(*this);
+  auto MyBlock = static_cast<KaxBlock *>(this->FindElt(EBML_INFO(KaxBlock)));
   MyBlock->ReleaseFrames();
 }
 
@@ -900,13 +900,13 @@ void KaxBlockGroup::SetBlockDuration(std::uint64_t TimeLength)
 {
   assert(ParentTrack);
   const std::int64_t scale = ParentTrack->GlobalTimestampScale();
-  const auto myDuration = FindChild<KaxBlockDuration>(*this);
+  const auto myDuration = static_cast<KaxBlockDuration *>(FindFirstElt(EBML_INFO(KaxBlockDuration), true));
   myDuration->SetValue(TimeLength / static_cast<std::uint64_t>(scale));
 }
 
 bool KaxBlockGroup::GetBlockDuration(std::uint64_t &TheTimestamp) const
 {
-  const auto myDuration = FindChild<KaxBlockDuration>(*this);
+  const auto myDuration = static_cast<KaxBlockDuration *>(FindElt(EBML_INFO(KaxBlockDuration)));
   if (!myDuration) {
     return false;
   }

--- a/src/KaxCluster.cpp
+++ b/src/KaxCluster.cpp
@@ -118,7 +118,7 @@ filepos_t KaxCluster::Render(IOCallback & output, KaxCues & CueToUpdate, const S
   filepos_t Result = 0;
 
   // update the timestamp of the Cluster before writing
-  auto ClusterTimestamp = FindChild<KaxClusterTimestamp>(*this);
+  auto ClusterTimestamp = static_cast<KaxClusterTimestamp *>(this->FindElt(EBML_INFO(KaxClusterTimestamp)));
   ClusterTimestamp->SetValue(GlobalTimestamp() / GlobalTimestampScale());
 
   if (Blobs.empty()) {
@@ -181,7 +181,7 @@ std::int16_t KaxCluster::GetBlockLocalTimestamp(std::uint64_t aGlobalTimestamp) 
 std::uint64_t KaxCluster::GetBlockGlobalTimestamp(std::int16_t LocalTimestamp)
 {
   if (!bFirstFrameInside) {
-    auto ClusterTimestamp = FindChild<KaxClusterTimestamp>(*this);
+    auto ClusterTimestamp = static_cast<KaxClusterTimestamp *>(this->FindElt(EBML_INFO(KaxClusterTimestamp)));
     assert (bFirstFrameInside); // use the InitTimestamp() hack for now
     MinTimestamp = MaxTimestamp = PreviousTimestamp = static_cast<std::uint64_t>(*static_cast<EbmlUInteger *>(ClusterTimestamp));
     bFirstFrameInside = true;

--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -97,7 +97,7 @@ const KaxCuePoint * KaxCues::GetTimestampPoint(std::uint64_t aTimestamp) const
     if (EbmlId(*e) == EBML_ID(KaxCuePoint)) {
       auto tmp = static_cast<const KaxCuePoint *>(e);
       // check the tile
-      auto aTime = FindChild<const KaxCueTime>(*tmp);
+      auto aTime = static_cast<const KaxCueTime *>(tmp->FindFirstElt(EBML_INFO(KaxCueTime)));
       if (aTime) {
         auto _Time = static_cast<std::uint64_t>(*aTime);
         if (_Time > aPrevTime && _Time < TimestampToLocate) {

--- a/src/KaxCuesData.cpp
+++ b/src/KaxCuesData.cpp
@@ -45,7 +45,7 @@ void KaxCuePoint::PositionSet(const KaxBlockGroup & BlockReference, std::uint64_
     }
   }
 
-  auto CodecState = FindChild<KaxCodecState>(BlockReference);
+  auto CodecState = static_cast<KaxCodecState *>(BlockReference.FindFirstElt(EBML_INFO(KaxCodecState)));
   if (CodecState) {
     auto &CueCodecState = AddNewChild<KaxCueCodecState>(NewPositions);
     CueCodecState.SetValue(BlockReference.GetParentCluster()->GetParentSegment()->GetRelativePosition(CodecState->GetElementPosition()));
@@ -96,7 +96,7 @@ void KaxCuePoint::PositionSet(const KaxInternalBlock & BlockReference, const Kax
 #endif // MATROSKA_VERSION
 
   if (BlockGroup) {
-    const auto CodecState = FindChild<const KaxCodecState>(*BlockGroup);
+    const auto CodecState = static_cast<const KaxCodecState *>(BlockGroup->FindFirstElt(EBML_INFO(KaxCodecState)));
     if (CodecState) {
       auto &CueCodecState = AddNewChild<KaxCueCodecState>(NewPositions);
       CueCodecState.SetValue(BlockGroup->GetParentCluster()->GetParentSegment()->GetRelativePosition(CodecState->GetElementPosition()));
@@ -127,11 +127,11 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
   auto theCmp = static_cast<const KaxCuePoint *>(Cmp);
 
   // compare timestamp
-  auto TimestampA = FindChild<const KaxCueTime>(*this);
+  auto TimestampA = static_cast<const KaxCueTime *>(FindElt(EBML_INFO(KaxCueTime)));
   if (!TimestampA)
     return false;
 
-  auto TimestampB = FindChild<const KaxCueTime>(*theCmp);
+  auto TimestampB = static_cast<const KaxCueTime *>(theCmp->FindElt(EBML_INFO(KaxCueTime)));
   if (!TimestampB)
     return false;
 
@@ -142,11 +142,11 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
     return false;
 
   // compare tracks (timestamp are equal)
-  const auto TrackA = FindChild<const KaxCueTrack>(*this);
+  const auto TrackA = static_cast<const KaxCueTrack *>(FindElt(EBML_INFO(KaxCueTrack)));
   if (!TrackA)
     return false;
 
-  const auto TrackB = FindChild<const KaxCueTrack>(*theCmp);
+  const auto TrackB = static_cast<const KaxCueTrack *>(theCmp->FindElt(EBML_INFO(KaxCueTrack)));
   if (!TrackB)
     return false;
 
@@ -161,7 +161,7 @@ bool KaxCuePoint::IsSmallerThan(const EbmlElement * Cmp) const
 
 bool KaxCuePoint::Timestamp(std::uint64_t & aTimestamp, std::uint64_t GlobalTimestampScale) const
 {
-  const auto aTime = FindChild<const KaxCueTime>(*this);
+  const auto aTime = static_cast<const KaxCueTime *>(FindFirstElt(EBML_INFO(KaxCueTime)));
   if (!aTime)
     return false;
   aTimestamp = static_cast<std::uint64_t>(*aTime) * GlobalTimestampScale;
@@ -176,22 +176,22 @@ const KaxCueTrackPositions * KaxCuePoint::GetSeekPosition() const
   const KaxCueTrackPositions * result = nullptr;
   std::uint64_t aPosition = 0xFFFFFFFFFFFFFFFLL;
   // find the position of the "earlier" Cluster
-  auto aPoss = FindChild<const KaxCueTrackPositions>(*this);
+  auto aPoss = static_cast<const KaxCueTrackPositions *>(FindFirstElt(EBML_INFO(KaxCueTrackPositions)));
   while (aPoss) {
-    auto aPos = FindChild<const KaxCueClusterPosition>(*aPoss);
+    auto aPos = static_cast<const KaxCueClusterPosition *>(aPoss->FindFirstElt(EBML_INFO(KaxCueClusterPosition)));
     if (aPos && static_cast<std::uint64_t>(*aPos) < aPosition) {
       aPosition = static_cast<std::uint64_t>(*aPos);
       result = aPoss;
     }
 
-    aPoss = FindNextChild<const KaxCueTrackPositions>(*this, *aPoss);
+    aPoss = static_cast<const KaxCueTrackPositions *>(FindNextElt(*aPoss));
   }
   return result;
 }
 
 std::uint64_t KaxCueTrackPositions::ClusterPosition() const
 {
-  const auto aPos = FindChild<const KaxCueClusterPosition>(*this);
+  const auto aPos = static_cast<const KaxCueClusterPosition *>(FindFirstElt(EBML_INFO(KaxCueClusterPosition)));
   if (!aPos)
     return 0;
 
@@ -200,7 +200,7 @@ std::uint64_t KaxCueTrackPositions::ClusterPosition() const
 
 std::uint16_t KaxCueTrackPositions::TrackNumber() const
 {
-  const auto aTrack = FindChild<const KaxCueTrack>(*this);
+  const auto aTrack = static_cast<const KaxCueTrack *>(FindFirstElt(EBML_INFO(KaxCueTrack)));
   if (!aTrack)
     return 0;
 

--- a/src/KaxSeekHead.cpp
+++ b/src/KaxSeekHead.cpp
@@ -39,16 +39,18 @@ KaxSeek * KaxSeekHead::IndexThis(const EbmlElement & aElt, const KaxSegment & Pa
 KaxSeek * KaxSeekHead::FindFirstOf(const EbmlCallbacks & Callbacks) const
 {
   // parse all the Entries and find the first to match the type
-  auto aElt = FindChild<KaxSeek>(*this);
+  auto aElt = static_cast<KaxSeek *>(FindFirstElt(EBML_INFO(KaxSeek)));
   while (aElt) {
-    const auto aId = FindChild<KaxSeekID>(*aElt);
-    if (aId != nullptr) {
+    auto it = std::find_if(aElt->begin(), aElt->end(), [&](auto Elt)
+      { return (EbmlId(*Elt) == EBML_ID(KaxSeekID)); });
+    if (it != aElt->end()) {
+      const auto aId = static_cast<KaxSeekID*>(*it);
       const auto aEbmlId = EbmlId(EbmlId::FromBuffer(aId->GetBuffer(), aId->GetSize()));
       if (aEbmlId == EBML_INFO_ID(Callbacks)) {
         return aElt;
       }
     }
-    aElt = FindNextChild<KaxSeek>(*this,*aElt);
+    aElt = static_cast<KaxSeek *>(FindNextElt(*aElt));
   }
 
   return nullptr;
@@ -71,7 +73,7 @@ KaxSeek * KaxSeekHead::FindNextOf(const KaxSeek &aPrev) const
 
 std::int64_t KaxSeek::Location() const
 {
-  auto aPos = FindChild<KaxSeekPosition>(*this);
+  auto aPos = static_cast<KaxSeekPosition*>(FindFirstElt(EBML_INFO(KaxSeekPosition)));
   if (!aPos)
     return 0;
   return static_cast<std::uint64_t>(*aPos);
@@ -79,7 +81,7 @@ std::int64_t KaxSeek::Location() const
 
 bool KaxSeek::IsEbmlId(const EbmlId & aId) const
 {
-  auto _Id = FindChild<KaxSeekID>(*this);
+  auto _Id = static_cast<KaxSeekID*>(FindFirstElt(EBML_INFO(KaxSeekID)));
   if (!_Id)
     return false;
   const auto aEbmlId = EbmlId(EbmlId::FromBuffer(_Id->GetBuffer(), _Id->GetSize()));
@@ -88,10 +90,10 @@ bool KaxSeek::IsEbmlId(const EbmlId & aId) const
 
 bool KaxSeek::IsEbmlId(const KaxSeek & aPoint) const
 {
-  auto _IdA = FindChild<KaxSeekID>(*this);
+  auto _IdA = static_cast<KaxSeekID*>(FindFirstElt(EBML_INFO(KaxSeekID)));
   if (!_IdA)
     return false;
-  auto _IdB = FindChild<KaxSeekID>(aPoint);
+  auto _IdB = static_cast<KaxSeekID*>(aPoint.FindFirstElt(EBML_INFO(KaxSeekID)));
   if (!_IdB)
     return false;
   const auto aEbmlIdA = EbmlId(EbmlId::FromBuffer(_IdA->GetBuffer(), _IdA->GetSize()));

--- a/test/ebml/test00.cpp
+++ b/test/ebml/test00.cpp
@@ -59,21 +59,21 @@ int main(void)
   // size is unknown and will always be, we can render it right away
   FirstSegment.Render(Ebml_file);
 
-  KaxAttachments * pAllAttachments = &GetChild<KaxAttachments>(FirstSegment);
+  KaxAttachments * pAllAttachments = static_cast<KaxAttachments *>(FirstSegment.FindFirstElt(EBML_INFO(KaxAttachments), true));
   if (pAllAttachments == NULL)
     return -1;
   pAllAttachments->SetSizeInfinite();
   // size is unknown and will always be, we can render it right away
   pAllAttachments->Render(Ebml_file);
 
-  KaxAttached * pAttachment1 = &GetChild<KaxAttached>(*pAllAttachments);
+  KaxAttached * pAttachment1 = static_cast<KaxAttached *>(pAllAttachments->FindFirstElt(EBML_INFO(KaxAttached), true));
   if (pAttachment1 == NULL)
     return -1;
-  KaxFileName * pFileName1 = &GetChild<KaxFileName>(*pAttachment1);
+  KaxFileName * pFileName1 = static_cast<KaxFileName *>(pAttachment1->FindFirstElt(EBML_INFO(KaxFileName), true));
   if (pFileName1 == NULL)
     return -1;
   pFileName1->SetValue(UTFstring{L"file1.txt"});
-  KaxFileData * pFileData1 = &GetChild<KaxFileData>(*pAttachment1);
+  KaxFileData * pFileData1 = static_cast<KaxFileData *>(pAttachment1->FindFirstElt(EBML_INFO(KaxFileData), true));
   if (pFileData1 == NULL)
     return -1;
   char Buffer1[] = "Ah ah ah !";
@@ -81,15 +81,15 @@ int main(void)
   // should produce an error if the size is not infinite and the data has been rendered
   pAttachment1->Render(Ebml_file);
 
-  KaxAttached * pAttachment2 = &AddNewChild<KaxAttached>(*pAllAttachments);
+  KaxAttached * pAttachment2 = static_cast<KaxAttached *>(pAllAttachments->AddNewElt(EBML_INFO(KaxAttached)));
   if (pAttachment2 == NULL)
     return -1;
-  KaxFileName * pFileName2 = &GetChild<KaxFileName>(*pAttachment2);
+  KaxFileName * pFileName2 = static_cast<KaxFileName *>(pAttachment2->FindFirstElt(EBML_INFO(KaxFileName), true));
   if (pFileName2 == NULL)
     return -1;
   pFileName2->SetValue(UTFstring{L"file2.txt"});
   // Add a void element (data is discarded)
-  EbmlVoid * pVoid = &GetChild<EbmlVoid>(*pAttachment2);
+  EbmlVoid * pVoid = static_cast<EbmlVoid *>(pAttachment2->FindFirstElt(EBML_INFO(EbmlVoid), true));
   if (pVoid == NULL)
     return -1;
   static_cast<EbmlBinary *>(pVoid)->SetBuffer((const binary*) Buffer1, countof(Buffer1));

--- a/test/mux/test8.cpp
+++ b/test/mux/test8.cpp
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
               // Extract the valuable data from the Block
 
               aBlockGroup.Read(aStream, EBML_CLASS_CONTEXT(KaxBlockGroup), UpperElementLevel, ElementLevel3, bAllowDummy);
-              KaxBlock * DataBlock = FindChild<KaxBlock>(aBlockGroup);
+              KaxBlock * DataBlock = static_cast<KaxBlock *>(aBlockGroup.FindElt(EBML_INFO(KaxBlock)));
               if (DataBlock != NULL) {
 //                DataBlock->ReadData(aStream.I_O());
                 DataBlock->SetParent(*SegmentCluster);
@@ -315,11 +315,11 @@ int main(int argc, char **argv)
               } else {
                 printf("   A BlockGroup without a Block !!!");
               }
-              KaxBlockDuration * BlockDuration = FindChild<KaxBlockDuration>(aBlockGroup);
+              KaxBlockDuration * BlockDuration = static_cast<KaxBlockDuration *>(aBlockGroup.FindElt(EBML_INFO(KaxBlockDuration)));
               if (BlockDuration != NULL) {
                 printf("  Block Duration %d scaled ticks : %ld ns\n", std::uint32_t(*BlockDuration), std::uint32_t(*BlockDuration) * TimestampScale);
               }
-              KaxReferenceBlock * RefTime = FindChild<KaxReferenceBlock>(aBlockGroup);
+              KaxReferenceBlock * RefTime = static_cast<KaxReferenceBlock *>(aBlockGroup.FindElt(EBML_INFO(KaxReferenceBlock)));
               if (RefTime != NULL) {
                 printf("  Reference frame at scaled (%d) timestamp %ld\n", std::int32_t(*RefTime), std::int32_t(std::int64_t(*RefTime) * TimestampScale));
               }


### PR DESCRIPTION
Reverts Matroska-Org/libmatroska#190

Unfortunately I merged to soon: many segfaults in MKVToolNix. Haven't debugged it yet.