### PR TITLE
add missing MATROSKA_DLL_API for KaxMatroska

### DIFF
--- a/src/KaxContexts.cpp
+++ b/src/KaxContexts.cpp
@@ -22,7 +22,7 @@ DEFINE_SEMANTIC_ITEM(true, true, EbmlHead)
 DEFINE_SEMANTIC_ITEM(false, false, KaxSegment)
 DEFINE_END_SEMANTIC(KaxMatroska)
 
-DEFINE_MKX_CONTEXT(KaxMatroska)
+MATROSKA_DLL_API DEFINE_MKX_CONTEXT(KaxMatroska)
 
 // for the moment
 const EbmlSemanticContextMaster & GetKaxGlobal_Context()


### PR DESCRIPTION
It will still need https://github.com/Matroska-Org/libebml/pull/292 to compile properly on Windows.