### PR TITLE
fix compilation by including header in which std::find is defined

### DIFF
--- a/src/KaxCues.cpp
+++ b/src/KaxCues.cpp
@@ -5,6 +5,7 @@
   \file
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
+#include <algorithm>
 #include <cassert>
 
 #include "matroska/KaxCues.h"

--- a/src/KaxSeekHead.cpp
+++ b/src/KaxSeekHead.cpp
@@ -5,6 +5,8 @@
   \file
   \author Steve Lhomme     <robux4 @ users.sf.net>
 */
+#include <algorithm>
+
 #include "matroska/KaxSeekHead.h"
 #include "matroska/KaxContexts.h"
 #include "matroska/KaxSegment.h"


### PR DESCRIPTION
Compilation breaks when the `algorithm` header isn't included indirectly anymore. This happens with certain combinations of compiler/C++ library/C++ mode, e.g. clang++ 17/libstdc++ 14.1/C++20