### PR TITLE
[1.x] use a single enum for the Chapter Codec IDs

### DIFF
--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -1210,6 +1210,14 @@ typedef enum {
 } MatroskaChapterSkipType;
 
 /**
+ *Contains the type of the codec used for processing.
+ */
+typedef enum {
+  MATROSKA_CHAPPROCESSCODECID_MATROSKA_SCRIPT  = 0, // Chapter commands using the Matroska Script codec.
+  MATROSKA_CHAPPROCESSCODECID_DVD_MENU         = 1, // Chapter commands using the DVD-like codec.
+} MatroskaChapProcessCodecID;
+
+/**
  *Defines when the process command **SHOULD** be handled
  */
 typedef enum {

--- a/matroska/KaxSemantic.h
+++ b/matroska/KaxSemantic.h
@@ -907,22 +907,6 @@ typedef enum {
 } MatroskaTrackEncodingCompAlgo;
 
 /**
- *This `ChapterTranslate` applies to this chapter codec of the given chapter edition(s); see (#chapprocesscodecid-element).
- */
-typedef enum {
-  MATROSKA_CHAPTERTRANSLATECODEC_MATROSKA_SCRIPT  = 0, // Chapter commands using the Matroska Script codec.
-  MATROSKA_CHAPTERTRANSLATECODEC_DVD_MENU         = 1, // Chapter commands using the DVD-like codec.
-} MatroskaChapterTranslateCodec;
-
-/**
- *This `TrackTranslate` applies to this chapter codec of the given chapter edition(s); see (#chapprocesscodecid-element).
- */
-typedef enum {
-  MATROSKA_TRACKTRANSLATECODEC_MATROSKA_SCRIPT  = 0, // Chapter commands using the Matroska Script codec.
-  MATROSKA_TRACKTRANSLATECODEC_DVD_MENU         = 1, // Chapter commands using the DVD-like codec.
-} MatroskaTrackTranslateCodec;
-
-/**
  *Specify whether the video frames in this track are interlaced.
  */
 typedef enum {


### PR DESCRIPTION
This is how RFC 9559 defines the value.

The `MatroskaChapProcessCodecID` was missing.

This is breaking the API (not the ABI) but I doubt anyone is using these (recent from #67) enum values.
I can add some `using MatroskaChapterTranslateCodec = MatroskaChapProcessCodecID;` if needed and also define the old names to the new name if needed.