### PR TITLE
[1.x] CI: update targets to test gcc 7 and 13

### DIFF
--- a/.github/workflows/linux-gcc10.yaml
+++ b/.github/workflows/linux-gcc10.yaml
@@ -10,8 +10,6 @@ jobs:
     name: libmatroska for Linux gcc10
     runs-on: ubuntu-latest
     steps:
-      - uses: lukka/get-cmake@latest
-
       - name: Get pushed code
         uses: actions/checkout@v3
       

--- a/.github/workflows/linux-gcc9.yaml
+++ b/.github/workflows/linux-gcc9.yaml
@@ -1,4 +1,4 @@
-name: "Linux gcc10 Build"
+name: "Linux gcc9 Build"
 on:
   push:
     branches: [ v1.x ]
@@ -7,15 +7,15 @@ on:
 
 jobs:
   build_libmatroska:
-    name: libmatroska for Linux gcc10
-    runs-on: ubuntu-latest
+    name: libmatroska for Linux gcc9
+    runs-on: ubuntu-20.04
     steps:
       - name: Get pushed code
         uses: actions/checkout@v3
-      
+
       - name: Checkout libebml
         uses: actions/checkout@v3
-        with: 
+        with:
           repository: Matroska-Org/libebml
           path: libebml
           ref: v1.x
@@ -23,8 +23,8 @@ jobs:
       - name: Configure libebml
         run: cmake -S libebml -B libebml/_build
         env:
-          CC:  gcc-10
-          CXX: g++-10
+          CC:  gcc-9
+          CXX: g++-9
 
       - name: Build libebml
         run: cmake --build libebml/_build --parallel
@@ -35,8 +35,8 @@ jobs:
       - name: Configure CMake
         run: cmake -S . -B _build -DEBML_DIR="${GITHUB_WORKSPACE}/_built/lib/cmake/EBML"
         env:
-          CC:  gcc-10
-          CXX: g++-10
+          CC:  gcc-9
+          CXX: g++-9
 
       - name: Build with CMake
         run: cmake --build _build --parallel

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -10,7 +10,6 @@ jobs:
     name: libmatroska for Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: lukka/get-cmake@latest
 
       - name: Get pushed code
         uses: actions/checkout@v3

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -10,8 +10,6 @@ jobs:
     name: libmatroska for macOS
     runs-on: macos-latest
     steps:
-      - uses: lukka/get-cmake@latest
-
       - name: Get pushed code
         uses: actions/checkout@v3
       

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -14,8 +14,6 @@ jobs:
       matrix:
         config: [Debug, Release]
     steps:
-      - uses: lukka/get-cmake@latest
-
       - name: Get pushed code
         uses: actions/checkout@v3
       

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Linux](https://github.com/Matroska-Org/libmatroska/actions/workflows/linux.yaml/badge.svg)](https://github.com/Matroska-Org/libmatroska/actions/workflows/linux.yaml)
 [![Windows](https://github.com/Matroska-Org/libmatroska/actions/workflows/windows.yaml/badge.svg)](https://github.com/Matroska-Org/libmatroska/actions/workflows/windows.yaml)
 [![macOS](https://github.com/Matroska-Org/libmatroska/actions/workflows/macos.yaml/badge.svg)](https://github.com/Matroska-Org/libmatroska/actions/workflows/macos.yaml)
-[![GCC10](https://github.com/Matroska-Org/libmatroska/actions/workflows/linux-gcc10.yaml/badge.svg)](https://github.com/Matroska-Org/libmatroska/actions/workflows/linux-gcc10.yaml)
+[![GCC9](https://github.com/Matroska-Org/libmatroska/actions/workflows/linux-gcc9.yaml/badge.svg)](https://github.com/Matroska-Org/libmatroska/actions/workflows/linux-gcc9.yaml)
 
 # libmatroska
 a C++ library to parse and create Matroska files


### PR DESCRIPTION
Until the latest ubuntu changes to a newer gcc.