### PR TITLE
CI: switch to g++ 10 for oldest g++ test

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        cxx: ['g++-9', 'clang++-13']
+        cxx: ['g++-10', 'clang++-13']
     env:
       CMAKE_OPTIONS: -DDEV_MODE=ON -DBUILD_TESTING=ON
       CMAKE_MATROSKA_OPTIONS: -DBUILD_EXAMPLES=ON

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -108,7 +108,7 @@ jobs:
           branch: edge
           arch: ${{matrix.platform}}
           packages: >
-            build-base cmake
+            build-base cmake git
 
       - name: Checkout libebml
         uses: actions/checkout@v4


### PR DESCRIPTION
Ubuntu 22.04 no longer has g++-9 but it has gcc-9...