### PR TITLE
KaxBlock: release read buffers on EndOfStream error

### DIFF
--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -748,6 +748,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
   } catch (const SafeReadIOCallback::EndOfStreamX&) {
     SetValueIsSet(false);
 
+    ReleaseFrames();
     myBuffers.clear();
     SizeList.clear();
     Timestamp          = 0;


### PR DESCRIPTION
It cannot be done by the caller as we reset myBuffers on error.

Leaking since 4457e70466dcc77984202a05525428383cb74fe3.