### PR TITLE
[1.x] KaxBlock: release read buffers on EndOfStream error

### DIFF
--- a/src/KaxBlock.cpp
+++ b/src/KaxBlock.cpp
@@ -705,6 +705,7 @@ filepos_t KaxInternalBlock::ReadData(IOCallback & input, ScopeMode ReadFully)
   } catch (SafeReadIOCallback::EndOfStreamX &) {
     SetValueIsSet(false);
 
+    ReleaseFrames();
     myBuffers.clear();
     SizeList.clear();
     Timecode           = 0;


### PR DESCRIPTION
It cannot be done by the caller as we reset myBuffers on error.

Leaking since 4457e70466dcc77984202a05525428383cb74fe3.