### PR TITLE
[1.x] KaxDefines: do not allow infinite sizes on all Master elements except Segment+Cluster

### DIFF
--- a/matroska/KaxDefines.h
+++ b/matroska/KaxDefines.h
@@ -62,6 +62,7 @@
 class MATROSKA_DLL_API x : public EbmlMaster { \
     public: x(EBML_EXTRA_PARAM); \
     x(const x & ElementToClone) :EbmlMaster(ElementToClone) {} \
+    bool SetSizeInfinite(bool finite = true) override { return !finite; } \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_MASTER_CONS(x)     DECLARE_MKX_CONTEXT(x) \
@@ -150,6 +151,7 @@ class MATROSKA_DLL_API x : public EbmlMaster { \
 class MATROSKA_DLL_API x : public EbmlMaster { \
     public: x(); \
     x(const x & ElementToClone) :EbmlMaster(ElementToClone) {} \
+    bool SetSizeInfinite(bool finite = true) override { return !finite; } \
     EBML_CONCRETE_CLASS(x)
 
 #define DECLARE_MKX_MASTER_CONS(x)     DECLARE_MKX_CONTEXT(x) \


### PR DESCRIPTION
Only Segment [^1] and Clusters [^2] are allowed to be infinite.
They both use the `DECLARE_MKX_MASTER_CONS()` macro and are the only ones to use them.

[^1]: https://www.rfc-editor.org/rfc/rfc9559#section-5.1
[^2]: https://www.rfc-editor.org/rfc/rfc9559#section-5.1.3